### PR TITLE
Tiny modification when returning

### DIFF
--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -119,14 +119,13 @@ class PhysicsEnginePlatformer:
         hit_list = \
             check_for_collision_with_list(self.player_sprite,
                                           self.platforms)
-
-        result = False
+        
+        self.player_sprite.center_y += 2
 
         if len(hit_list) > 0:
-            result = True
-
-        self.player_sprite.center_y += 2
-        return result
+            return True
+        else:
+            return result
 
     def update(self):
         """

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -125,7 +125,7 @@ class PhysicsEnginePlatformer:
         if len(hit_list) > 0:
             return True
         else:
-            return result
+            return False
 
     def update(self):
         """


### PR DESCRIPTION
Simply remove another variable when completing the task, then returning the value necessary.

Seems a better alternative to creating a variable with a default value, performing a check, modifying said variable if necessary, and returning.