### PR TITLE
Automate thumbnail generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
   - pip install -r requirements.txt
 
 script:
-  - python doc/preprocess_files.py
   - sphinx-build -b html doc doc/build/html
   - coverage run --omit=arcade/examples/* --source=arcade setup.py test
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 # Run the generate quick API index script
+# Then generate thumbnails if they do not exist
 import runpy
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python
 
+# Run the generate quick API index script
+import runpy
+
+
+runpy.run_path('preprocess_files.py', run_name='__main__')
+
 BUILD = 0
 VERSION = "1.3.4"
 RELEASE = VERSION

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,6 +5,7 @@ import runpy
 
 
 runpy.run_path('preprocess_files.py', run_name='__main__')
+runpy.run_path('generate_example_thumbnails.py', run_name='__main__')
 
 BUILD = 0
 VERSION = "1.3.4"

--- a/doc/generate_example_thumbnails.py
+++ b/doc/generate_example_thumbnails.py
@@ -1,0 +1,24 @@
+import os, sys
+
+def main():
+    if not os.path.exists('examples/thumbs'):
+        os.makedirs('examples/thumbs')
+        generate_thumbnails()
+    else:
+        print('Thumbnails already exist, skipping generation')
+
+
+def generate_thumbnails():
+    print('Generating thumbnails')
+
+    if sys.platform == 'linux':
+        command = 'mogrify'
+    else:
+        command = 'magick mogrify'
+
+    os.chdir('examples')
+    os.system(command + ' -resize 200x158 -extent 200x158 -background transparent -path thumbs *.png')
+    # os.system(command + ' -resize 200x158 -extent 200x158 -background transparent -path thumbs *.gif')
+
+if __name__ == '__main__':
+    main()

--- a/doc/generate_example_thumbnails.py
+++ b/doc/generate_example_thumbnails.py
@@ -18,6 +18,7 @@ def generate_thumbnails():
 
     os.chdir('examples')
     os.system(command + ' -resize 200x158 -extent 200x158 -background transparent -path thumbs *.png')
+    # Do we want animated thumbnails?
     # os.system(command + ' -resize 200x158 -extent 200x158 -background transparent -path thumbs *.gif')
 
 if __name__ == '__main__':

--- a/make.bat
+++ b/make.bat
@@ -27,7 +27,6 @@ pip uninstall -y arcade
 for /r %%i in (dist\*) do pip install "%%i"
 
 rem Build the documentation
-python doc/preprocess_files.py
 sphinx-build -b html doc doc/build/html
 
 rem Run tests and do code coverage
@@ -41,7 +40,6 @@ rem -- Make the documentation
 :makedoc
 
 rmdir /s /q "doc\build"
-python doc/preprocess_files.py
 sphinx-build -n -b html doc doc/build/html
 
 GOTO end

--- a/make.sh
+++ b/make.sh
@@ -10,7 +10,6 @@ for file in dist/*
 do
   pip3 install $file
 done
-python3 doc/preprocess_files.py
 sphinx-build -b html doc doc/build/html
 coverage run --source arcade setup.py test
 coverage report -m


### PR DESCRIPTION
Issue #206 

When sphinx-build runs it opens and executes the file `doc/conf.py`. 

I made `doc/conf.py` call `doc/preprocess_files.py`.
I removed `preprocess_files.py` calls from `make.bat`, `make.sh` and `travis.yaml` 

I created `doc/generate_example_thumbnails.py`.
It checks for the directory `doc/examples/thumbs`. If that directory exists the script does nothing. If the directory does not exist it executes the appropriate command to generate the thumbnails.

`doc/conf.py` makes the call to `doc/generate_example_thumbnails.py`.

This PR does have some issues.
 - I commented out the line in `generate_example_thumbnails.py` that creates the gifs. The generated documentation and the live documentation are currently not using gif thumbnails.
 - I can not test this on windows or macOS. I do not know if I chose the correct command on line 17 of `generate_example_thumbnails`
 - The examples documentation page is trying to use a thumbnail that can not be generated because the source png does not exists. The thumbnail is on the live documentation though.