### PR TITLE
Setting window as arcades window

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -7,6 +7,7 @@ from numbers import Number
 
 from arcade.window_commands import set_viewport
 from arcade.window_commands import get_viewport
+from arcade.window_commands import set_window
 
 import pyglet
 
@@ -48,6 +49,7 @@ class Window(pyglet.window.Window):
         self.set_update_rate(1 / 60)
         super().set_fullscreen(fullscreen)
         self.invalid = False
+        set_window(self)
         # set_viewport(0, self.width, 0, self.height)
 
     def update(self, delta_time: float):


### PR DESCRIPTION
This enables access to the window instance through arcade.get_window(), if one is using a custom window class. As a new user I expected arcade.get_window() to give me current window instance. I was quite disappointed when this was not the case. I was able to achieve it by using this code:
`
window = MyWindow()
window.setup()
arcade.set_window(window)
arcade.run()
`
It works, but it would be nice if it was done automatically on window creation.