### PR TITLE
Fix sound playback of WAV files on Linux.

### DIFF
--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -129,14 +129,20 @@ def _playsound_osx(nssound):
         nssound.copy().play()
 
 
+players = []
+MAX_PLAYERS = 5
 def _playsound_unix(sound):
     """Play a sound using GStreamer.
     Inspired by this:
     https://gstreamer.freedesktop.org/documentation/tutorials/playback/playbin-usage.html
     """
     # pathname2url escapes non-URL-safe characters
-    if isinstance(sound, pyglet.media.sources.riff.WaveSource):
-        sound.play()
+    global players
+    if isinstance(sound, pyglet.media.sources.base.StaticSource):
+        while len(players) >= MAX_PLAYERS:
+            p = players.pop(0)
+            p.delete()
+        players.append(sound.play())
         return
 
     import os
@@ -170,7 +176,7 @@ def _playsound_unix(sound):
 
 def _load_sound_unix(filename: str) -> typing.Any:
     if filename.endswith(".wav"):
-        my_sound = pyglet.media.load(filename)
+        my_sound = pyglet.media.StaticSource(pyglet.media.load(filename))
         return my_sound
     else:
         return filename
@@ -201,6 +207,3 @@ else:
     load_sound = _load_sound_unix
 
 del system
-
-
-


### PR DESCRIPTION
This commit fixes sound playback on Linux (issue #224). As suggested by @dangillet, WAV files are loaded to memory as StaticSource and are played back by multiple players.

This fix assumes that WAV files are used for short sound effects only. A better solution would be to distinguish between sound and music in the API as suggested by @dangillet.