### PR TITLE
Fix Spatial Hashing for Sprite update

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -343,11 +343,13 @@ class Sprite:
     def __lt__(self, other):
         return self.texture.texture_id.value < other.texture.texture_id.value
 
-    def clear_spatial_hashes(self):
+    def update_spatial_hashes(self):
+        """Update this sprite's spatial hash for any that in which it has been
+        included."""
         for sprite_list in self.sprite_lists:
             if sprite_list.use_spatial_hash and sprite_list.spatial_hash is not None:
                 try:
-                    sprite_list.spatial_hash.remove_object(self)
+                    sprite_list.recalculate_spatial_hash(self)
                 except:
                     print("Warning, attempt to remove item from spatial hash that doesn't exist in the hash.")
 
@@ -428,7 +430,7 @@ arcade.Sprite("arcade/examples/images/playerShip1_orange.png", scale)
     def _set_center_x(self, new_value: float):
         """ Set the center x coordinate of the sprite. """
         if new_value != self._position[0]:
-            self.clear_spatial_hashes()
+            self.update_spatial_hashes()
             self._position[0] = new_value
             self._point_list_cache = None
 
@@ -442,7 +444,7 @@ arcade.Sprite("arcade/examples/images/playerShip1_orange.png", scale)
     def _set_center_y(self, new_value: float):
         """ Set the center y coordinate of the sprite. """
         if new_value != self._position[1]:
-            self.clear_spatial_hashes()
+            self.update_spatial_hashes()
             self._position[1] = new_value
             self._point_list_cache = None
 
@@ -475,7 +477,7 @@ arcade.Sprite("arcade/examples/images/playerShip1_orange.png", scale)
     def _set_angle(self, new_value: float):
         """ Set the angle of the sprite's rotation. """
         if new_value != self._angle:
-            self.clear_spatial_hashes()
+            self.update_spatial_hashes()
             self._angle = new_value
             self._point_list_cache = None
 

--- a/arcade/sprite_list.py
+++ b/arcade/sprite_list.py
@@ -368,7 +368,7 @@ class SpriteList(Generic[T]):
     def recalculate_spatial_hash(self, item: T):
         if self.use_spatial_hash:
             self.spatial_hash.remove_object(item)
-            self.spatial_hash.append_object(item)
+            self.spatial_hash.insert_object_for_box(item)
 
     def remove(self, item: T):
         """

--- a/arcade/sprite_list.py
+++ b/arcade/sprite_list.py
@@ -289,7 +289,9 @@ class SpatialHash:
                 # append to each intersecting cell
                 close_by_sprites.extend(self.contents.setdefault((i, j), []))
 
-        return close_by_sprites
+        # Prevent duplicate collision checks on sprites hashed to more tha one
+        # cell
+        return list(set(close_by_sprites))
 
 
 T = TypeVar('T', bound=Sprite)


### PR DESCRIPTION
Spatial hashing had a few issues causing the example game `sprite_collect_coins_move_circle` to fail to properly detect collisions with a moving player and coins.  Applied several fixes:
- Modified the `clear_spatial_hashes` method on Sprite to instead update the spatial hashes.
- Fixed a broken doctest for `check_for_collision_with_list` by preventing SpatialHash from returning duplicate references when the same sprite appeared in multiple hash cells.
- Removed an obsolete reference to `append_object` on SpatialHash