### PR TITLE
Cleanup arcade examples (docs, typos, inconsistencies, simple bugs) (#295)

### DIFF
--- a/arcade/examples/array_backed_grid.py
+++ b/arcade/examples/array_backed_grid.py
@@ -21,9 +21,10 @@ HEIGHT = 30
 # and on the edges of the screen.
 MARGIN = 5
 
-# Do the math to figure out oiur screen dimensions
+# Do the math to figure out our screen dimensions
 SCREEN_WIDTH = (WIDTH + MARGIN) * COLUMN_COUNT + MARGIN
 SCREEN_HEIGHT = (HEIGHT + MARGIN) * ROW_COUNT + MARGIN
+SCREEN_TITLE = "Array Backed Grid Example"
 
 
 class MyGame(arcade.Window):
@@ -31,12 +32,12 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Set up the application.
         """
 
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Create a 2 dimensional array. A two dimensional
         # array is simply a list of lists.
@@ -98,7 +99,7 @@ class MyGame(arcade.Window):
 
 def main():
 
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/array_backed_grid_buffered.py
+++ b/arcade/examples/array_backed_grid_buffered.py
@@ -23,21 +23,21 @@ HEIGHT = 30
 # and on the edges of the screen.
 MARGIN = 5
 
-# Do the math to figure out oiur screen dimensions
+# Do the math to figure out our screen dimensions
 SCREEN_WIDTH = (WIDTH + MARGIN) * COLUMN_COUNT + MARGIN
 SCREEN_HEIGHT = (HEIGHT + MARGIN) * ROW_COUNT + MARGIN
-
+SCREEN_TITLE = "Array Backed Grid Buffered Example"
 
 class MyGame(arcade.Window):
     """
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Set up the application.
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         self.shape_list = None
 
@@ -104,7 +104,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/asteroid_smasher.py
+++ b/arcade/examples/asteroid_smasher.py
@@ -19,6 +19,7 @@ SCALE = 0.5
 OFFSCREEN_SPACE = 300
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Asteroid Smasher"
 LEFT_LIMIT = -OFFSCREEN_SPACE
 RIGHT_LIMIT = SCREEN_WIDTH + OFFSCREEN_SPACE
 BOTTOM_LIMIT = -OFFSCREEN_SPACE
@@ -141,7 +142,7 @@ class MyGame(arcade.Window):
     """ Main application class. """
 
     def __init__(self):
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT)
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/bouncing_ball.py
+++ b/arcade/examples/bouncing_ball.py
@@ -12,6 +12,7 @@ import arcade
 # Size of the screen
 SCREEN_WIDTH = 600
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Bouncing Ball Example"
 
 # Size of the circle.
 CIRCLE_RADIUS = 20
@@ -79,7 +80,7 @@ draw.delta_y = 0
 
 def main():
     # Open up our window
-    arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, "Bouncing Ball")
+    arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.set_background_color(arcade.color.WHITE)
 
     # Tell the computer to call the draw command at the specified interval.

--- a/arcade/examples/bouncing_balls.py
+++ b/arcade/examples/bouncing_balls.py
@@ -14,7 +14,7 @@ import random
 # Size of the screen
 SCREEN_WIDTH = 600
 SCREEN_HEIGHT = 600
-
+SCREEN_TITLE = "Bouncing Balls Example"
 
 class Ball:
     """
@@ -56,7 +56,7 @@ class MyGame(arcade.Window):
     """ Main application class. """
 
     def __init__(self):
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Bouncing Balls Demo")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
         self.ball_list = []
         ball = make_ball()
         self.ball_list.append(ball)

--- a/arcade/examples/bouncing_rectangle.py
+++ b/arcade/examples/bouncing_rectangle.py
@@ -26,6 +26,7 @@ import arcade
 # Size of the screen
 SCREEN_WIDTH = 600
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Bouncing Rectangle Example"
 
 # Size of the rectangle
 RECT_WIDTH = 50
@@ -79,7 +80,7 @@ on_draw.delta_y = 130  # Initial change in y
 
 def main():
     # Open up our window
-    arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, "Bouncing Rectangle Example")
+    arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.set_background_color(arcade.color.WHITE)
 
     # Tell the computer to call the draw command at the specified interval.

--- a/arcade/examples/decorator_drawing_example.py
+++ b/arcade/examples/decorator_drawing_example.py
@@ -11,6 +11,7 @@ import random
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Drawing With Decorators Example"
 
 
 def draw_background(window):
@@ -118,5 +119,5 @@ def draw(window):
 
 
 if __name__ == "__main__":
-    arcade.decorator.run(SCREEN_WIDTH, SCREEN_HEIGHT, title="Drawing With Decorators")
+    arcade.decorator.run(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 

--- a/arcade/examples/decorator_test.py
+++ b/arcade/examples/decorator_test.py
@@ -1,3 +1,10 @@
+"""
+Decorator Test
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.decorator_test
+"""
+
 import arcade
 
 
@@ -8,12 +15,12 @@ class Ball:
         self.radius = radius
 
 
-@arcade.decorator.init
+@arcade.decorator.setup
 def setup_my_game(window):
     window.ball: Ball = Ball()
 
 
-@arcade.decorator.animate
+@arcade.decorator.update
 def move_ball(window, delta_time):
     window.ball.x_position += window.ball.velocity * delta_time
 
@@ -44,4 +51,4 @@ def press_space(key, key_modifiers):
 
 
 if __name__ == "__main__":
-    arcade.decorator.run(700, 600, background_color=arcade.color.MAHOGANY)
+    arcade.decorator.run(700, 600, "Decorator Test", background_color=arcade.color.MAHOGANY)

--- a/arcade/examples/drawing_primitives.py
+++ b/arcade/examples/drawing_primitives.py
@@ -29,7 +29,7 @@ file_path = os.path.dirname(os.path.abspath(__file__))
 os.chdir(file_path)
 
 # Open the window. Set the window title and dimensions (width and height)
-arcade.open_window(600, 600, "Drawing Example")
+arcade.open_window(600, 600, "Drawing Primitives Example")
 
 # Set the background color to white
 # For a list of named colors see

--- a/arcade/examples/drawing_text.py
+++ b/arcade/examples/drawing_text.py
@@ -8,15 +8,15 @@ import arcade
 
 SCREEN_WIDTH = 500
 SCREEN_HEIGHT = 500
-
+SCREEN_TITLE = "Drawing Text Example"
 
 class MyGame(arcade.Window):
     """
     Main application class.
     """
 
-    def __init__(self, width, height):
-        super().__init__(width, height, title="Drawing Text Example")
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         arcade.set_background_color(arcade.color.WHITE)
         self.text_angle = 0
@@ -98,7 +98,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/drawing_with_functions.py
+++ b/arcade/examples/drawing_with_functions.py
@@ -17,7 +17,7 @@ import arcade
 # Constants - variables that do not change
 SCREEN_WIDTH = 600
 SCREEN_HEIGHT = 600
-
+SCREEN_TITLE = "Drawing With Functions Example"
 
 def draw_background():
     """
@@ -67,7 +67,7 @@ def main():
     """
 
     # Open the window
-    arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, "Drawing With Functions")
+    arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
     # Start the render process. This must be done before any drawing commands.
     arcade.start_render()

--- a/arcade/examples/drawing_with_loops.py
+++ b/arcade/examples/drawing_with_loops.py
@@ -14,6 +14,7 @@ import random
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Drawing With Loops Example"
 
 
 def draw_background():
@@ -67,7 +68,7 @@ def main():
     """
 
     # Open the window
-    arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, "Drawing With Loops")
+    arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
     # Start the render process. This must be done before any drawing commands.
     arcade.start_render()

--- a/arcade/examples/full_screen_example.py
+++ b/arcade/examples/full_screen_example.py
@@ -16,6 +16,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Full Screen Example"
 
 # How many pixels to keep as a minimum margin between the character
 # and the edge of the screen.
@@ -33,7 +34,7 @@ class MyGame(arcade.Window):
         """
         # Open a window in full screen mode. Remove fullscreen=True if
         # you don't want to start this way.
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, fullscreen=True)
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE, fullscreen=True)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/gradients.py
+++ b/arcade/examples/gradients.py
@@ -1,4 +1,5 @@
 """
+Drawing Gradients
 
 If Python and Arcade are installed, this example can be run from the command line with:
 python -m arcade.examples.gradients
@@ -8,6 +9,7 @@ import arcade
 # Do the math to figure out our screen dimensions
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Gradients Example"
 
 
 class MyGame(arcade.Window):
@@ -15,12 +17,12 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Set up the application.
         """
 
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         arcade.set_background_color(arcade.color.BLACK)
 
@@ -82,7 +84,7 @@ class MyGame(arcade.Window):
 
 def main():
 
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/gui_text_button.py
+++ b/arcade/examples/gui_text_button.py
@@ -10,6 +10,7 @@ import os
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "GUI Text Buton Example"
 
 
 class TextButton:
@@ -141,8 +142,8 @@ class MyGame(arcade.Window):
     with your own code. Don't leave 'pass' in this program.
     """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -228,7 +229,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    game = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    game = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     game.setup()
     arcade.run()
 

--- a/arcade/examples/happy_face.py
+++ b/arcade/examples/happy_face.py
@@ -1,11 +1,19 @@
+"""
+Drawing an example happy face
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.happy_face
+"""
+
 import arcade
 
 # Set constants for the screen size
 SCREEN_WIDTH = 600
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Happy Face Example"
 
 # Open the window. Set the window title and dimensions
-arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, "Drawing Example")
+arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
 # Set the background color
 arcade.set_background_color(arcade.color.WHITE)

--- a/arcade/examples/instruction_and_game_over_screens.py
+++ b/arcade/examples/instruction_and_game_over_screens.py
@@ -17,6 +17,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Instruction and Game Over Screens Example"
 
 # These numbers represent "states" that the game can be in.
 INSTRUCTIONS_PAGE_0 = 0
@@ -30,10 +31,10 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, screen_width, screen_height):
+    def __init__(self, screen_width, screen_height, title):
         """ Constructor """
         # Call the parent constructor. Required and must be the first line.
-        super().__init__(screen_width, screen_height)
+        super().__init__(screen_width, screen_height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -213,7 +214,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/isometric_example.py
+++ b/arcade/examples/isometric_example.py
@@ -3,6 +3,9 @@ Example of displaying an isometric map.
 
 Isometric map created with Tiled Map Editor: https://www.mapeditor.org/
 Tiles by Kenney: http://kenney.nl/assets/isometric-dungeon-tiles
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.isometric_example
 """
 
 import arcade
@@ -12,6 +15,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Isometric Example"
 
 # How many pixels to keep as a minimum margin between the character
 # and the edge of the screen.
@@ -34,11 +38,11 @@ def read_sprite_list(grid, sprite_list):
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -180,7 +184,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/joystick.py
+++ b/arcade/examples/joystick.py
@@ -10,6 +10,7 @@ import arcade
 # Set up the constants
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Joystick Control Example"
 
 RECT_WIDTH = 50
 RECT_HEIGHT = 50
@@ -22,8 +23,8 @@ class MyGame(arcade.Window):
     """
     Main application class.
     """
-    def __init__(self, width, height):
-        super().__init__(width, height, title="joystick control")
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
         self.player = None
         self.left_down = False
 
@@ -138,7 +139,7 @@ class Rectangle:
 
 
 def main():
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/lines_buffered.py
+++ b/arcade/examples/lines_buffered.py
@@ -1,8 +1,5 @@
 """
-Array Backed Grid
-
-Show how to use a two-dimensional list/array to back the display of a
-grid on-screen.
+Using a Vertex Buffer Object With Lines
 
 If Python and Arcade are installed, this example can be run from the command line with:
 python -m arcade.examples.lines_buffered
@@ -10,21 +7,21 @@ python -m arcade.examples.lines_buffered
 import arcade
 import random
 
-# Do the math to figure out oiur screen dimensions
+# Do the math to figure out our screen dimensions
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
-
+SCREEN_TITLE = "Vertex Buffer Object With Lines Example"
 
 class MyGame(arcade.Window):
     """
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Set up the application.
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         self.shape_list = arcade.ShapeElementList()
         point_list = ((0, 50),
@@ -72,7 +69,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/maze_depth_first.py
+++ b/arcade/examples/maze_depth_first.py
@@ -20,6 +20,7 @@ SPRITE_SIZE = NATIVE_SPRITE_SIZE * SPRITE_SCALING
 
 SCREEN_WIDTH = 1000
 SCREEN_HEIGHT = 700
+SCREEN_TITLE = "Maze Depth First Example"
 
 MOVEMENT_SPEED = 8
 
@@ -84,11 +85,11 @@ def make_maze_depth_first(maze_width, maze_height):
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -302,7 +303,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/maze_recursive.py
+++ b/arcade/examples/maze_recursive.py
@@ -7,7 +7,7 @@ at https://en.wikipedia.org/wiki/Maze_generation_algorithm
 Artwork from http://kenney.nl
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.maze_depth_first
+python -m arcade.examples.maze_recursive
 """
 import random
 import arcade
@@ -20,6 +20,7 @@ SPRITE_SIZE = NATIVE_SPRITE_SIZE * SPRITE_SCALING
 
 SCREEN_WIDTH = 1000
 SCREEN_HEIGHT = 700
+SCREEN_TITLE = "Maze Recursive Example"
 
 MOVEMENT_SPEED = 8
 
@@ -137,11 +138,11 @@ def make_maze_recursion(maze_width, maze_height):
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -355,7 +356,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/mountains_midpoint_displacement.py
+++ b/arcade/examples/mountains_midpoint_displacement.py
@@ -1,5 +1,5 @@
 """
-Example "Arcade" library code.
+Mountains Midpoint Displacement
 
 Create a random mountain range.
 Original idea and some code from:
@@ -16,6 +16,7 @@ import bisect
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 700
+SCREEN_TITLE = "Mountains Midpoint Displacement Example"
 
 
 # Iterative midpoint vertical displacement
@@ -173,5 +174,5 @@ def draw(window):
 
 if __name__ == "__main__":
     arcade.decorator.run(SCREEN_WIDTH, SCREEN_HEIGHT,
-                         title="Drawing With Decorators",
+                         title=SCREEN_TITLE,
                          background_color=arcade.color.WHITE)

--- a/arcade/examples/mountains_random_walk.py
+++ b/arcade/examples/mountains_random_walk.py
@@ -1,5 +1,5 @@
 """
-Example "Arcade" library code.
+Mountains Random Walk
 
 Idea and algorithm from:
 https://hackernoon.com/a-procedural-landscape-experiment-4efe1826906f
@@ -15,6 +15,7 @@ import pyglet
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 700
+SCREEN_TITLE = "Mountains Random Walk Example"
 
 
 def create_mountain_range(height_min, height_max, color_start, color_end):
@@ -112,5 +113,5 @@ def draw(window):
 
 
 if __name__ == "__main__":
-    arcade.decorator.run(SCREEN_WIDTH, SCREEN_HEIGHT, title="Drawing With Decorators", background_color=arcade.color.WHITE)
+    arcade.decorator.run(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE, background_color=arcade.color.WHITE)
 

--- a/arcade/examples/move_joystick.py
+++ b/arcade/examples/move_joystick.py
@@ -10,6 +10,7 @@ import arcade
 
 SCREEN_WIDTH = 640
 SCREEN_HEIGHT = 480
+SCREEN_TITLE = "Move Joystick Example"
 MOVEMENT_SPEED = 5
 DEAD_ZONE = 0.02
 
@@ -103,7 +104,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(640, 480, "Drawing Example")
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/move_keyboard.py
+++ b/arcade/examples/move_keyboard.py
@@ -9,6 +9,7 @@ import arcade
 
 SCREEN_WIDTH = 640
 SCREEN_HEIGHT = 480
+SCREEN_TITLE = "Move Keyboard Example"
 MOVEMENT_SPEED = 3
 
 
@@ -90,7 +91,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(640, 480, "Drawing Example")
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/move_mouse.py
+++ b/arcade/examples/move_mouse.py
@@ -10,6 +10,7 @@ import arcade
 
 SCREEN_WIDTH = 640
 SCREEN_HEIGHT = 480
+SCREEN_TITLE = "Move Mouse Example"
 
 
 class Ball:
@@ -69,7 +70,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(640, 480, "Drawing Example")
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/performance_comparison/simple_sprite_draw_arcade.py
+++ b/arcade/examples/performance_comparison/simple_sprite_draw_arcade.py
@@ -16,7 +16,7 @@ import timeit
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 700
-
+SCREEN_TITLE = "Simple Sprite Stress Test"
 
 class MyGame(arcade.Window):
     """ Our custom Window Class"""
@@ -25,7 +25,7 @@ class MyGame(arcade.Window):
         """ Initializer """
 
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprite Example")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         self.draw_time = 0
 

--- a/arcade/examples/performance_comparison/simple_sprite_draw_pygame.py
+++ b/arcade/examples/performance_comparison/simple_sprite_draw_pygame.py
@@ -9,7 +9,6 @@ If Python and Arcade are installed, this example can be run from the command lin
 python -m arcade.examples.performance_comparison.simple_sprite_draw_pygame
 """
 
-import os
 import timeit
 import pygame
 
@@ -17,6 +16,7 @@ import pygame
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 700
+SCREEN_TITLE = "Pygame Sprite Stress Test"
 
 
 # This class represents the ball
@@ -30,7 +30,7 @@ class Block(pygame.sprite.Sprite):
 
         # Set background color to be transparent. Adjust to WHITE if your
         # background is WHITE.
-        self.image.set_colorkey(pygame.color.black)
+        self.image.set_colorkey(pygame.Color("black"))
 
         self.rect = self.image.get_rect()
 
@@ -42,6 +42,7 @@ def main():
 
     # Set the height and width of the screen
     screen = pygame.display.set_mode([SCREEN_WIDTH, SCREEN_HEIGHT])
+    pygame.display.set_caption(SCREEN_TITLE)
 
     # Sprite list
     all_sprites_list = pygame.sprite.Group()
@@ -80,7 +81,7 @@ def main():
         draw_start_time = timeit.default_timer()
 
         # Clear the screen
-        screen.fill(pygame.color.white)
+        screen.fill(pygame.Color("white"))
 
         # Draw all the spites
         all_sprites_list.draw(screen)
@@ -89,7 +90,7 @@ def main():
 
         sprite_count = len(all_sprites_list)
         output = f"Drawing time: {draw_time:.4f} for {sprite_count} sprites."
-        text = font.render(output, True, pygame.color.white)
+        text = font.render(output, True, pygame.Color("white"))
         screen.blit(text, [20, SCREEN_HEIGHT - 40])
 
         pygame.display.flip()

--- a/arcade/examples/performance_comparison/simple_sprite_draw_pyglet.py
+++ b/arcade/examples/performance_comparison/simple_sprite_draw_pyglet.py
@@ -16,6 +16,7 @@ import timeit
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 700
+SCREEN_TITLE = "Pyglet Sprite Stress Test"
 
 
 class MyGame(pyglet.window.Window):
@@ -25,7 +26,7 @@ class MyGame(pyglet.window.Window):
         """ Initializer """
 
         # Call the parent class initializer
-        super().__init__(height=SCREEN_HEIGHT, width=SCREEN_WIDTH)
+        super().__init__(height=SCREEN_HEIGHT, width=SCREEN_WIDTH, caption=SCREEN_TITLE)
 
         self.draw_time = 0
 

--- a/arcade/examples/perlin_noise_1.py
+++ b/arcade/examples/perlin_noise_1.py
@@ -1,11 +1,8 @@
 """
-Array Backed Grid
-
-Show how to use a two-dimensional list/array to back the display of a
-grid on-screen.
+Perlin Noise 1
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.array_backed_grid_buffered
+python -m arcade.examples.perlin_noise_1
 
 TODO: This code doesn't work properly, and isn't currently listed in the examples.
 """
@@ -25,9 +22,10 @@ HEIGHT = 10
 # and on the edges of the screen.
 MARGIN = 2
 
-# Do the math to figure out oiur screen dimensions
+# Do the math to figure out our screen dimensions
 SCREEN_WIDTH = (WIDTH + MARGIN) * COLUMN_COUNT + MARGIN
 SCREEN_HEIGHT = (HEIGHT + MARGIN) * ROW_COUNT + MARGIN
+SCREEN_TITLE = "Perlin Noise 1 Example"
 
 # Perlin noise generator from:
 # https://stackoverflow.com/questions/42147776/producing-2d-perlin-noise-with-numpy
@@ -77,11 +75,11 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Set up the application.
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         self.shape_list = None
 
@@ -151,7 +149,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/perlin_noise_2.py
+++ b/arcade/examples/perlin_noise_2.py
@@ -1,11 +1,8 @@
 """
-Array Backed Grid
-
-Show how to use a two-dimensional list/array to back the display of a
-grid on-screen.
+Perlin Noise 2
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.array_backed_grid_buffered
+python -m arcade.examples.perlin_noise_2
 
 TODO: This code doesn't work properly, and isn't currently listed in the examples.
 """
@@ -25,9 +22,10 @@ HEIGHT = 10
 # and on the edges of the screen.
 MARGIN = 2
 
-# Do the math to figure out oiur screen dimensions
+# Do the math to figure out our screen dimensions
 SCREEN_WIDTH = (WIDTH + MARGIN) * COLUMN_COUNT + MARGIN
 SCREEN_HEIGHT = (HEIGHT + MARGIN) * ROW_COUNT + MARGIN
+SCREEN_TITLE = "Perlin Noise 2 Example"
 
 # Perlin noise generator from:
 # https://stackoverflow.com/questions/42147776/producing-2d-perlin-noise-with-numpy
@@ -77,11 +75,11 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Set up the application.
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
         self.background_list = None
         arcade.set_background_color(arcade.color.BLACK)
 
@@ -144,7 +142,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/pinball.py
+++ b/arcade/examples/pinball.py
@@ -1,8 +1,8 @@
 """
-Array Backed Grid
+Pinball
 
-Show how to use a two-dimensional list/array to back the display of a
-grid on-screen.
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.pinball
 """
 import arcade
 import pymunk
@@ -10,9 +10,10 @@ import math
 import random
 import os
 
-# Do the math to figure out oiur screen dimensions
+# Do the math to figure out our screen dimensions
 SCREEN_WIDTH = 390
 SCREEN_HEIGHT = 732
+SCREEN_TITLE = "Pinball"
 BALL_RADIUS = 0.53
 
 class Shape:
@@ -64,11 +65,11 @@ class MyApplication(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Set up the application.
         """
-        super().__init__(width, height, resizable=True)
+        super().__init__(width, height, title, resizable=True)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -254,7 +255,7 @@ class MyApplication(arcade.Window):
 
 
 def main():
-    window = MyApplication(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyApplication(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/procedural_caves_bsp.py
+++ b/arcade/examples/procedural_caves_bsp.py
@@ -5,12 +5,16 @@ Binary Space Partitioning (BSP)
 For more information, see:
 http://roguebasin.roguelikedevelopment.org/index.php?title=Basic_BSP_Dungeon_generation
 https://github.com/DanaL/RLDungeonGenerator
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.procedural_caves_bsp
 """
 
 import random
 import arcade
 import timeit
 import math
+import os
 
 # Sprite scaling. Make this larger, like 0.5 to zoom in and add
 # 'mystery' to what you can see. Make it smaller, like 0.1 to see
@@ -36,6 +40,7 @@ VIEWPORT_MARGIN = 300
 # How big the window is
 WINDOW_WIDTH = 800
 WINDOW_HEIGHT = 600
+WINDOW_TITLE = "Procedural Caves BSP Example"
 
 MERGE_SPRITES = True
 
@@ -245,8 +250,15 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
+
+        # Set the working directory (where we expect to find files) to the same
+        # directory this .py file is in. You can leave this out of your own
+        # code, but it is needed to easily run the examples using "python -m"
+        # as mentioned at the top of this program.
+        file_path = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(file_path)
 
         self.grid = None
         self.wall_list = None
@@ -434,7 +446,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    game = MyGame(WINDOW_WIDTH, WINDOW_HEIGHT)
+    game = MyGame(WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_TITLE)
     game.setup()
     arcade.run()
 

--- a/arcade/examples/procedural_caves_cellular.py
+++ b/arcade/examples/procedural_caves_cellular.py
@@ -3,11 +3,15 @@ This example procedurally develops a random cave based on cellular automata.
 
 For more information, see:
 https://gamedevelopment.tutsplus.com/tutorials/generate-random-cave-levels-using-cellular-automata--gamedev-9664
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.procedural_caves_cellular
 """
 
 import random
 import arcade
 import timeit
+import os
 
 # Sprite scaling. Make this larger, like 0.5 to zoom in and add
 # 'mystery' to what you can see. Make it smaller, like 0.1 to see
@@ -34,7 +38,7 @@ VIEWPORT_MARGIN = 300
 # How big the window is
 WINDOW_WIDTH = 800
 WINDOW_HEIGHT = 600
-
+WINDOW_TITLE = "Procedural Caves Cellular Automata Example"
 # If true, rather than each block being a separate sprite, blocks on rows
 # will be merged into one sprite.
 MERGE_SPRITES = False
@@ -101,7 +105,14 @@ class MyGame(arcade.Window):
     """
 
     def __init__(self):
-        super().__init__(WINDOW_WIDTH, WINDOW_HEIGHT, resizable=True)
+        super().__init__(WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_TITLE, resizable=True)
+
+        # Set the working directory (where we expect to find files) to the same
+        # directory this .py file is in. You can leave this out of your own
+        # code, but it is needed to easily run the examples using "python -m"
+        # as mentioned at the top of this program.
+        file_path = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(file_path)
 
         self.grid = None
         self.wall_list = None

--- a/arcade/examples/pymunk_2.py
+++ b/arcade/examples/pymunk_2.py
@@ -1,3 +1,9 @@
+"""
+Pymunk 2
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.pymunk_2
+"""
 import arcade
 import pymunk
 import timeit
@@ -5,6 +11,7 @@ import math
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 800
+SCREEN_TITLE = "Pymunk 2 Example"
 
 """
 Key bindings:
@@ -46,8 +53,8 @@ class BoxSprite(PhysicsSprite):
 class MyApplication(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
         arcade.set_background_color(arcade.color.DARK_SLATE_GRAY)
 
         # -- Pymunk
@@ -299,6 +306,6 @@ class MyApplication(arcade.Window):
         # Save the time it took to do this.
         self.processing_time = timeit.default_timer() - start_time
 
-window = MyApplication(SCREEN_WIDTH, SCREEN_HEIGHT)
+window = MyApplication(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
 arcade.run()

--- a/arcade/examples/pymunk_box_stacks.py
+++ b/arcade/examples/pymunk_box_stacks.py
@@ -23,7 +23,7 @@ import os
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 800
-
+SCREEN_TITLE = "Pymunk Box Stacks Example"
 
 class PhysicsSprite(arcade.Sprite):
     def __init__(self, pymunk_shape, filename):
@@ -48,8 +48,8 @@ class BoxSprite(PhysicsSprite):
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -200,7 +200,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
     arcade.run()
 

--- a/arcade/examples/pymunk_pegboard.py
+++ b/arcade/examples/pymunk_pegboard.py
@@ -24,6 +24,7 @@ import os
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 800
+SCREEN_TITLE = "Pymunk Pegboard Example"
 
 
 class CircleSprite(arcade.Sprite):
@@ -37,8 +38,8 @@ class CircleSprite(arcade.Sprite):
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -168,7 +169,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
     arcade.run()
 

--- a/arcade/examples/pymunk_platformer/constants.py
+++ b/arcade/examples/pymunk_platformer/constants.py
@@ -1,6 +1,7 @@
 # Size of the window
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 800
+SCREEN_TITLE = 'Pymunk Platformer'
 
 # Default friction used for sprites, unless otherwise specified
 DEFAULT_FRICTION = 0.2

--- a/arcade/examples/pymunk_platformer/main_window.py
+++ b/arcade/examples/pymunk_platformer/main_window.py
@@ -32,8 +32,8 @@ from constants import *
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -301,7 +301,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
     arcade.run()
 

--- a/arcade/examples/pymunk_test.py
+++ b/arcade/examples/pymunk_test.py
@@ -10,7 +10,7 @@ pip install pymunk
 Artwork from http://kenney.nl
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.pymunk_box_stacks
+python -m arcade.examples.pymunk_test
 
 Click and drag with the mouse to move the boxes.
 """
@@ -23,6 +23,7 @@ import os
 
 SCREEN_WIDTH = 1800
 SCREEN_HEIGHT = 800
+SCREEN_TITLE = "Pymunk test"
 
 
 class PhysicsSprite(arcade.Sprite):
@@ -48,8 +49,8 @@ class BoxSprite(PhysicsSprite):
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -205,7 +206,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
     arcade.run()
 

--- a/arcade/examples/radar_sweep.py
+++ b/arcade/examples/radar_sweep.py
@@ -11,6 +11,7 @@ import math
 # Set up the constants
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Radar Sweep Example"
 
 # These constants control the particulars about the radar
 CENTER_X = SCREEN_WIDTH // 2
@@ -50,7 +51,7 @@ on_draw.angle = 0
 def main():
 
     # Open up our window
-    arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, "Radar Sweep Example")
+    arcade.open_window(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.set_background_color(arcade.color.BLACK)
 
     # Tell the computer to call the draw command at the specified interval.

--- a/arcade/examples/resizable_window.py
+++ b/arcade/examples/resizable_window.py
@@ -8,6 +8,7 @@ import arcade
 
 SCREEN_WIDTH = 500
 SCREEN_HEIGHT = 500
+SCREEN_TITLE = "Resizing Window Example"
 START = 0
 END = 2000
 STEP = 50
@@ -18,8 +19,8 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
-        super().__init__(width, height, title="Resizing Window Example", resizable=True)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title, resizable=True)
 
         arcade.set_background_color(arcade.color.WHITE)
 
@@ -53,7 +54,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/run_all_examples.py
+++ b/arcade/examples/run_all_examples.py
@@ -1,0 +1,52 @@
+"""
+Run All Examples
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.run_all_examples
+"""
+import subprocess
+import argparse
+import os
+import glob
+
+EXAMPLE_SUBDIR = "arcade/examples"
+
+def _get_short_name(fullpath):
+    return os.path.splitext(os.path.basename(fullpath))[0]
+
+def _get_examples(start_path):
+    query_path = os.path.join(start_path, "*.py")
+    examples = glob.glob(query_path)
+    examples = [_get_short_name(e) for e in examples]
+    examples = [e for e in examples if e != "run_all_examples"]
+    examples = [e for e in examples if not e.startswith('_')]
+    examples = ["arcade.examples." + e for e in examples if not e.startswith('_')]
+    return examples
+
+def run_examples(indices_in_range, index_skip_list):
+    """Run all examples in the arcade/examples directory"""
+    examples = _get_examples(EXAMPLE_SUBDIR)
+    print("Found {} examples in {}".format(len(examples), EXAMPLE_SUBDIR))
+
+    # run examples
+    for (idx, example) in enumerate(examples):
+        if indices_in_range is not None and idx not in indices_in_range:
+            continue
+        if index_skip_list is not None and idx in index_skip_list:
+            continue
+        print('%s %s (index #%d of %d)' % ('=' * 20, example, idx, len(examples) - 1))
+        cmd = 'python -m ' + example
+        subprocess.call(cmd, shell=True)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--range", nargs=2, metavar=("LO", "HI"),
+                        help="range of indexes, inclusive")
+    parser.add_argument("--skip", nargs="*", metavar="IDX",
+                        help="list of indexes to skip")
+    args = parser.parse_args()
+    if args.range is not None:
+        args.range = range(int(args.range[0]), int(args.range[1]) + 1)
+    if args.skip is not None:
+        args.skip = [int(i) for i in args.skip]
+    run_examples(args.range, args.skip)

--- a/arcade/examples/shape_list_demo_1.py
+++ b/arcade/examples/shape_list_demo_1.py
@@ -5,6 +5,9 @@ For me this takes about 0.850 seconds per frame.
 
 It is slow because we load all the points and all the colors to the card every
 time.
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.shape_list_demo_1
 """
 
 import arcade
@@ -12,6 +15,7 @@ import timeit
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 800
+SCREEN_TITLE = "Shape List Demo 1"
 
 SQUARE_WIDTH = 5
 SQUARE_HEIGHT = 5
@@ -20,8 +24,8 @@ SQUARE_SPACING = 10
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         arcade.set_background_color(arcade.color.DARK_SLATE_GRAY)
 
@@ -52,7 +56,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
     arcade.run()
 

--- a/arcade/examples/shape_list_demo_2.py
+++ b/arcade/examples/shape_list_demo_2.py
@@ -8,6 +8,9 @@ graphics card figures out some optimizations.
 It is faster than demo 1 because we aren't loading the vertices and color
 to the card again and again. It isn't very fast because we are still sending
 individual draw commands to the graphics card for each square.
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.shape_list_demo_2
 """
 
 import arcade
@@ -15,6 +18,7 @@ import timeit
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 800
+SCREEN_TITLE = "Shape List Demo 2"
 
 SQUARE_WIDTH = 5
 SQUARE_HEIGHT = 5
@@ -24,8 +28,8 @@ SQUARE_SPACING = 10
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         arcade.set_background_color(arcade.color.DARK_SLATE_GRAY)
 
@@ -65,7 +69,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/shape_list_demo_3.py
+++ b/arcade/examples/shape_list_demo_3.py
@@ -7,6 +7,9 @@ We then draw all the squares with one drawing command.
 
 This runs in about 0.000 seconds for me. It is much more complex in code
 than the prior two examples, but the pay-off in speed is huge.
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.shape_list_demo_3
 """
 
 import arcade
@@ -14,6 +17,7 @@ import timeit
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 800
+SCREEN_TITLE = "Shape List Demo 3"
 
 HALF_SQUARE_WIDTH = 2.5
 HALF_SQUARE_HEIGHT = 2.5
@@ -23,8 +27,8 @@ SQUARE_SPACING = 10
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         arcade.set_background_color(arcade.color.DARK_SLATE_GRAY)
 
@@ -91,7 +95,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/shape_list_demo_person.py
+++ b/arcade/examples/shape_list_demo_person.py
@@ -9,6 +9,7 @@ import arcade
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Shape List Demo Person"
 
 
 def make_person(head_radius,
@@ -75,7 +76,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Shape Demo")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         head_radius = 30
         chest_height = 110

--- a/arcade/examples/shape_list_demo_skylines.py
+++ b/arcade/examples/shape_list_demo_skylines.py
@@ -10,6 +10,7 @@ import time
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Skyline Using Buffered Shapes"
 
 
 def make_star_field(star_count):
@@ -132,7 +133,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Skyline Using Buffered Shapes")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         self.stars = make_star_field(150)
         self.skyline1 = make_skyline(SCREEN_WIDTH * 5, 250, (80, 80, 80))

--- a/arcade/examples/shape_list_non_center_rotate.py
+++ b/arcade/examples/shape_list_non_center_rotate.py
@@ -1,7 +1,14 @@
+"""
+Shape List Non-center Rotation Demo
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.shape_list_non_center_rotate
+"""
 import arcade
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Shape List Non-center Rotation Demo"
 
 
 def make_shape():
@@ -26,7 +33,7 @@ class MyGame(arcade.Window):
 
     def __init__(self):
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Shape Demo")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         self.shape_list = make_shape()
 
@@ -53,7 +60,6 @@ class MyGame(arcade.Window):
 
 def main():
     window = MyGame()
-    window.setup()
     arcade.run()
 
 

--- a/arcade/examples/shapes.py
+++ b/arcade/examples/shapes.py
@@ -23,6 +23,7 @@ import random
 # Set up the constants
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Shapes!"
 
 RECT_WIDTH = 50
 RECT_HEIGHT = 50
@@ -67,7 +68,7 @@ class MyGame(arcade.Window):
     """ Main application class. """
 
     def __init__(self):
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, title="Shapes!")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
         self.shape_list = None
 
     def setup(self):

--- a/arcade/examples/shapes_buffered.py
+++ b/arcade/examples/shapes_buffered.py
@@ -4,7 +4,7 @@ Shapes buffered in ShapeElementList
 Show how to use a ShapeElementList to display multiple shapes on-screen.
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.lines_buffered
+python -m arcade.examples.shapes_buffered
 """
 import arcade
 import random
@@ -12,6 +12,7 @@ import random
 # Do the math to figure out our screen dimensions
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Buffered Shapes"
 
 
 class MyGame(arcade.Window):
@@ -19,11 +20,11 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Set up the application.
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         self.shape_list = arcade.ShapeElementList()
         self.shape_list.center_x = SCREEN_WIDTH // 2
@@ -109,7 +110,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     arcade.run()
 
 

--- a/arcade/examples/snow.py
+++ b/arcade/examples/snow.py
@@ -14,6 +14,7 @@ import arcade
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Snow"
 
 
 class Snowflake:
@@ -34,14 +35,14 @@ class Snowflake:
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         :param width:
         :param height:
         """
         # Calls "__init__" of parent class (arcade.Window) to setup screen
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Sprite lists
         self.snowflake_list = None
@@ -104,7 +105,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.start_snowfall()
     arcade.run()
 

--- a/arcade/examples/sound.py
+++ b/arcade/examples/sound.py
@@ -1,6 +1,12 @@
+"""
+Sound Demo
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.sound
+"""
 import arcade
 
 arcade.open_window(300, 300, "Sound Demo")
-#laser_sound = arcade.load_sound("sounds/laser1.wav")
-#arcade.play_sound(laser_sound)
+laser_sound = arcade.load_sound("sounds/laser1.wav")
+arcade.play_sound(laser_sound)
 arcade.run()

--- a/arcade/examples/sound_test.py
+++ b/arcade/examples/sound_test.py
@@ -1,5 +1,8 @@
 """ Test for sound in Arcade.
 (May only work for windows at current time)
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.sound_test
 """
 
 import arcade
@@ -8,6 +11,7 @@ import os
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sound Test Example"
 
 window = None
 
@@ -18,7 +22,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprites and Bullets Demo")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_bullets.py
+++ b/arcade/examples/sprite_bullets.py
@@ -19,6 +19,7 @@ COIN_COUNT = 50
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprites and Bullets Example"
 
 BULLET_SPEED = 5
 
@@ -29,7 +30,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprites and Bullets Demo")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_bullets_aimed.py
+++ b/arcade/examples/sprite_bullets_aimed.py
@@ -21,6 +21,7 @@ COIN_COUNT = 50
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprites and Bullets Aimed Example"
 
 BULLET_SPEED = 5
 
@@ -33,7 +34,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprites and Bullets Demo")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_bullets_enemy_aims.py
+++ b/arcade/examples/sprite_bullets_enemy_aims.py
@@ -11,13 +11,14 @@ import os
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprites and Bullets Enemy Aims Example"
 BULLET_SPEED = 4
 
 class MyGame(arcade.Window):
     """ Main application class """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -129,7 +130,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_bullets_periodic.py
+++ b/arcade/examples/sprite_bullets_periodic.py
@@ -9,13 +9,14 @@ import os
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprites and Periodic Bullets Example"
 
 
 class MyGame(arcade.Window):
     """ Main application class """
 
     def __init__(self):
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT)
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_bullets_random.py
+++ b/arcade/examples/sprite_bullets_random.py
@@ -10,13 +10,14 @@ import os
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprites and Random Bullets Example"
 
 
 class MyGame(arcade.Window):
     """ Main application class """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -96,7 +97,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_change_coins.py
+++ b/arcade/examples/sprite_change_coins.py
@@ -17,6 +17,7 @@ SPRITE_SCALING = 1
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Change Coins"
 
 
 class Collectable(arcade.Sprite):
@@ -32,8 +33,8 @@ class MyGame(arcade.Window):
     Main application class.a
     """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -43,7 +44,7 @@ class MyGame(arcade.Window):
         os.chdir(file_path)
 
         # Sprite lists
-        self.all_sprites_list = None
+        self.player_list = None
         self.coin_list = None
 
         # Set up the player
@@ -132,7 +133,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_collect_coins.py
+++ b/arcade/examples/sprite_collect_coins.py
@@ -20,6 +20,7 @@ COIN_COUNT = 50
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Collect Coins Example"
 
 
 class MyGame(arcade.Window):
@@ -28,7 +29,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprite Example")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_collect_coins_background.py
+++ b/arcade/examples/sprite_collect_coins_background.py
@@ -1,5 +1,5 @@
 """
-Sprite Collect Coins
+Sprite Collect Coins with Background
 
 Simple program to show basic sprite usage.
 
@@ -16,6 +16,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 1024
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Collect Coins with Background Example"
 
 
 class MyGame(arcade.Window):
@@ -23,11 +24,11 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """ Initializer """
 
         # Call the parent class initializer
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -129,7 +130,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_collect_coins_diff_levels.py
+++ b/arcade/examples/sprite_collect_coins_diff_levels.py
@@ -1,5 +1,5 @@
 """
-Sprite Collect Coins
+Sprite Collect Coins with Different Levels
 
 Simple program to show basic sprite usage.
 
@@ -17,6 +17,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Collect Coins with Different Levels Example"
 
 
 class FallingCoin(arcade.Sprite):
@@ -52,11 +53,11 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """ Initialize """
 
         # Call the parent class initializer
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -192,7 +193,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_collect_coins_move_bouncing.py
+++ b/arcade/examples/sprite_collect_coins_move_bouncing.py
@@ -1,5 +1,5 @@
 """
-Sprite Collect Coins
+Sprite Collect Moving and Bouncing Coins
 
 Simple program to show basic sprite usage.
 
@@ -20,6 +20,7 @@ COIN_COUNT = 50
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Collect Moving and Bouncing Coins Example"
 
 
 class Coin(arcade.Sprite):
@@ -57,7 +58,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprite Example")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_collect_coins_move_circle.py
+++ b/arcade/examples/sprite_collect_coins_move_circle.py
@@ -1,5 +1,5 @@
 """
-Sprite Collect Coins
+Sprite Collect Coins Moving in Circles
 
 Simple program to show basic sprite usage.
 
@@ -18,7 +18,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
-
+SCREEN_TITLE = "Sprite Collect Coins Moving in Circles Example"
 
 class Coin(arcade.Sprite):
 
@@ -56,9 +56,9 @@ class Coin(arcade.Sprite):
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
 
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -150,7 +150,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.start_new_game()
     arcade.run()
 

--- a/arcade/examples/sprite_collect_coins_move_down.py
+++ b/arcade/examples/sprite_collect_coins_move_down.py
@@ -1,5 +1,5 @@
 """
-Sprite Collect Coins
+Sprite Collect Coins Moving Down
 
 Simple program to show basic sprite usage.
 
@@ -20,6 +20,7 @@ COIN_COUNT = 50
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Collect Coins Moving Down Example"
 
 
 class Coin(arcade.Sprite):
@@ -53,7 +54,7 @@ class MyGame(arcade.Window):
         """ Initializer """
 
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprite Example")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_collect_coins_move_down_improved.py
+++ b/arcade/examples/sprite_collect_coins_move_down_improved.py
@@ -1,5 +1,5 @@
 """
-Sprite Collect Coins
+Sprite Collect Coins Moving Down Improved
 
 Simple program to show basic sprite usage.
 
@@ -17,6 +17,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Collect Coins Moving Down Improved Example"
 
 
 class Coin(arcade.Sprite):
@@ -43,9 +44,9 @@ class Coin(arcade.Sprite):
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
 
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -140,7 +141,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.start_new_game()
     arcade.run()
 

--- a/arcade/examples/sprite_collect_coins_with_stats.py
+++ b/arcade/examples/sprite_collect_coins_with_stats.py
@@ -1,12 +1,12 @@
 """
-Sprite Collect Coins
+Sprite Collect Coins with Stats
 
 Simple program to show basic sprite usage.
 
 Artwork from http://kenney.nl
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.sprite_collect_coins
+python -m arcade.examples.sprite_collect_coins_with_stats
 """
 
 import random
@@ -21,6 +21,7 @@ COIN_COUNT = 50
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Collect Coins with Stats Example"
 
 
 class MyGame(arcade.Window):
@@ -29,7 +30,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprite Example")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_collect_rotating.py
+++ b/arcade/examples/sprite_collect_rotating.py
@@ -1,12 +1,12 @@
 """
-Sprite Collect Coins
+Sprite Collect Rotating Coins
 
 Simple program to show basic sprite usage.
 
 Artwork from http://kenney.nl
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.sprite_collect_coins
+python -m arcade.examples.sprite_collect_rotating
 """
 
 import random
@@ -20,6 +20,7 @@ COIN_COUNT = 50
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Collect Rotating Coins Example"
 
 
 class Coin(arcade.Sprite):
@@ -38,7 +39,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprite Example")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_csv_map.py
+++ b/arcade/examples/sprite_csv_map.py
@@ -15,6 +15,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite CSV Map Example"
 SPRITE_PIXEL_SIZE = 128
 GRID_PIXEL_SIZE = (SPRITE_PIXEL_SIZE * SPRITE_SCALING)
 
@@ -52,7 +53,7 @@ class MyGame(arcade.Window):
         """
         Initializer
         """
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT)
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_enemies_in_platformer.py
+++ b/arcade/examples/sprite_enemies_in_platformer.py
@@ -17,6 +17,7 @@ SPRITE_SIZE = int(SPRITE_NATIVE_SIZE * SPRITE_SCALING)
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Enemies in a Platformer Example"
 
 # How many pixels to keep as a minimum margin between the character
 # and the edge of the screen.
@@ -36,7 +37,7 @@ class MyGame(arcade.Window):
         """
         Initializer
         """
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT)
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_explosion.py
+++ b/arcade/examples/sprite_explosion.py
@@ -1,5 +1,5 @@
 """
-Sprite Bullets
+Sprite Explosion
 
 Simple program to show basic sprite usage.
 
@@ -7,7 +7,7 @@ Artwork from http://kenney.nl
 Explosion graphics from http://www.explosiongenerator.com/
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.sprite_explosions
+python -m arcade.examples.sprite_explosion
 """
 import random
 import arcade
@@ -20,6 +20,7 @@ COIN_COUNT = 50
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Explosion Example"
 
 BULLET_SPEED = 5
 
@@ -56,7 +57,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprites and Bullets Demo")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_face_left_or_right.py
+++ b/arcade/examples/sprite_face_left_or_right.py
@@ -1,5 +1,5 @@
 """
-Sprite Move With Keyboard
+Sprite Facing Left or Right
 Face left or right depending on our direction
 
 Simple program to show basic sprite usage.
@@ -17,6 +17,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Face Left or Right Example"
 
 MOVEMENT_SPEED = 5
 
@@ -64,13 +65,13 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
 
         # Call the parent class initializer
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -143,7 +144,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_follow_simple.py
+++ b/arcade/examples/sprite_follow_simple.py
@@ -6,7 +6,7 @@ This moves towards the player in both the x and y direction.
 Artwork from http://kenney.nl
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.sprite_collect_coins
+python -m arcade.examples.sprite_follow_simple
 """
 
 import random
@@ -20,6 +20,7 @@ COIN_COUNT = 50
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Follow Player Simple Example"
 
 SPRITE_SPEED = 0.5
 
@@ -56,7 +57,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprite Example")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_follow_simple_2.py
+++ b/arcade/examples/sprite_follow_simple_2.py
@@ -8,7 +8,7 @@ way of following the player.
 Artwork from http://kenney.nl
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.sprite_collect_coins
+python -m arcade.examples.sprite_follow_simple_2
 """
 
 import random
@@ -24,6 +24,7 @@ COIN_SPEED = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Follow Player Simple Example 2"
 
 SPRITE_SPEED = 0.5
 
@@ -74,7 +75,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprite Example")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_move_angle.py
+++ b/arcade/examples/sprite_move_angle.py
@@ -1,3 +1,13 @@
+"""
+Move Sprite by Angle
+
+Simple program to show basic sprite usage.
+
+Artwork from http://kenney.nl
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.sprite_move_angle
+"""
 import arcade
 import os
 import math
@@ -6,6 +16,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Move Sprite by Angle Example"
 
 MOVEMENT_SPEED = 5
 ANGLE_SPEED = 5
@@ -40,13 +51,13 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
 
         # Call the parent class initializer
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -122,7 +133,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_move_animation.py
+++ b/arcade/examples/sprite_move_animation.py
@@ -1,5 +1,5 @@
 """
-Sprite Collect Coins
+Move with a Sprite Animation
 
 Simple program to show basic sprite usage.
 
@@ -14,6 +14,7 @@ import os
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Move with a Sprite Animation Example"
 
 COIN_SCALE = 0.5
 COIN_COUNT = 50
@@ -24,11 +25,11 @@ MOVEMENT_SPEED = 5
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -167,7 +168,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_move_joystick.py
+++ b/arcade/examples/sprite_move_joystick.py
@@ -1,5 +1,5 @@
 """
-Sprite Move With Joystick
+Move Sprite with Joystick
 
 Simple program to show basic sprite usage.
 
@@ -16,6 +16,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Move Sprite with Joystick Example"
 
 MOVEMENT_SPEED = 5
 DEAD_ZONE = 0.05
@@ -65,7 +66,7 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
@@ -78,7 +79,7 @@ class MyGame(arcade.Window):
         os.chdir(file_path)
 
         # Call the parent class initializer
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Variables that will hold sprite lists
         self.all_sprites_list = None
@@ -144,7 +145,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_move_keyboard.py
+++ b/arcade/examples/sprite_move_keyboard.py
@@ -1,5 +1,5 @@
 """
-Sprite Move With Keyboard
+Move Sprite With Keyboard
 
 Simple program to show moving a sprite with the keyboard.
 The sprite_move_keyboard_better.py example is slightly better
@@ -18,6 +18,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Move Sprite with Keyboard Example"
 
 MOVEMENT_SPEED = 5
 
@@ -44,13 +45,13 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
 
         # Call the parent class initializer
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -123,7 +124,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_move_keyboard_better.py
+++ b/arcade/examples/sprite_move_keyboard_better.py
@@ -1,5 +1,5 @@
 """
-Sprite Move With Keyboard
+Better Move Sprite With Keyboard
 
 Simple program to show moving a sprite with the keyboard.
 This is slightly better than sprite_move_keyboard.py example
@@ -18,6 +18,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Better Move Sprite with Keyboard Example"
 
 MOVEMENT_SPEED = 5
 
@@ -44,13 +45,13 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
 
         # Call the parent class initializer
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -147,7 +148,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_move_scrolling.py
+++ b/arcade/examples/sprite_move_scrolling.py
@@ -17,6 +17,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Move with Scrolling Screen Example"
 
 # How many pixels to keep as a minimum margin between the character
 # and the edge of the screen.
@@ -28,11 +29,11 @@ MOVEMENT_SPEED = 5
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -165,7 +166,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_move_walls.py
+++ b/arcade/examples/sprite_move_walls.py
@@ -16,6 +16,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Move with Walls Example"
 
 MOVEMENT_SPEED = 5
 
@@ -23,11 +24,11 @@ MOVEMENT_SPEED = 5
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -124,7 +125,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_moving_platforms.py
+++ b/arcade/examples/sprite_moving_platforms.py
@@ -1,4 +1,6 @@
 """
+Sprite with Moving Platforms
+
 Load a map stored in csv format, as exported by the program 'Tiled.'
 
 Artwork from http://kenney.nl
@@ -13,6 +15,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 1000
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite with Moving Platforms Example"
 SPRITE_PIXEL_SIZE = 128
 GRID_PIXEL_SIZE = (SPRITE_PIXEL_SIZE * SPRITE_SCALING)
 
@@ -42,12 +45,12 @@ def get_map():
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
 
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -277,7 +280,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_no_coins_on_walls.py
+++ b/arcade/examples/sprite_no_coins_on_walls.py
@@ -11,12 +11,14 @@ python -m arcade.examples.sprite_no_coins_on_walls
 """
 import arcade
 import random
+import os
 
 SPRITE_SCALING = 0.5
 SPRITE_SCALING_COIN = 0.2
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite No Coins on Walls Example"
 
 NUMBER_OF_COINS = 50
 
@@ -26,11 +28,19 @@ MOVEMENT_SPEED = 5
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
+
+        # Set the working directory (where we expect to find files) to the same
+        # directory this .py file is in. You can leave this out of your own
+        # code, but it is needed to easily run the examples using "python -m"
+        # as mentioned at the top of this program.
+        file_path = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(file_path)
+
         # Sprite lists
         self.all_sprites_list = None
         self.coin_list = None
@@ -146,7 +156,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_ramps.py
+++ b/arcade/examples/sprite_ramps.py
@@ -13,6 +13,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite with Ramps Example"
 SPRITE_PIXEL_SIZE = 128
 GRID_PIXEL_SIZE = (SPRITE_PIXEL_SIZE * SPRITE_SCALING)
 
@@ -42,12 +43,12 @@ def get_map():
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
 
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -238,7 +239,7 @@ class MyGame(arcade.Window):
 
 
 def main():
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.start_new_game()
     arcade.run()
 

--- a/arcade/examples/sprite_rooms.py
+++ b/arcade/examples/sprite_rooms.py
@@ -16,6 +16,7 @@ SPRITE_SIZE = int(SPRITE_NATIVE_SIZE * SPRITE_SCALING)
 
 SCREEN_WIDTH = SPRITE_SIZE * 14
 SCREEN_HEIGHT = SPRITE_SIZE * 10
+SCREEN_TITLE = "Sprite Rooms Example"
 
 MOVEMENT_SPEED = 5
 
@@ -125,11 +126,11 @@ def setup_room_2():
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """
         Initializer
         """
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own
@@ -237,7 +238,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/sprite_simple_platformer.py
+++ b/arcade/examples/sprite_simple_platformer.py
@@ -16,6 +16,7 @@ SPRITE_NATIVE_SIZE = 128
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Simple Platformer"
 
 # How many pixels to keep as a minimum margin between the character
 # and the edge of the screen.
@@ -36,7 +37,7 @@ class MyGame(arcade.Window):
         Initializer
         """
 
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT)
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_tiled_map.py
+++ b/arcade/examples/sprite_tiled_map.py
@@ -16,6 +16,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Tiled Map Example"
 SPRITE_PIXEL_SIZE = 128
 GRID_PIXEL_SIZE = (SPRITE_PIXEL_SIZE * SPRITE_SCALING)
 
@@ -39,7 +40,7 @@ class MyGame(arcade.Window):
         """
         Initializer
         """
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT)
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/sprite_tiled_map_with_levels.py
+++ b/arcade/examples/sprite_tiled_map_with_levels.py
@@ -1,6 +1,5 @@
-
 """
-Load a Tiled map file
+Load a Tiled map file with Levels
 
 Artwork from: http://kenney.nl
 Tiled available from: http://www.mapeditor.org/
@@ -17,6 +16,7 @@ SPRITE_SCALING = 0.5
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Sprite Tiled Map with Levels Example"
 SPRITE_PIXEL_SIZE = 128
 GRID_PIXEL_SIZE = (SPRITE_PIXEL_SIZE * SPRITE_SCALING)
 
@@ -40,7 +40,7 @@ class MyGame(arcade.Window):
         """
         Initializer
         """
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT)
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/starting_template.py
+++ b/arcade/examples/starting_template.py
@@ -11,6 +11,7 @@ import arcade
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Starting Template"
 
 
 class MyGame(arcade.Window):
@@ -22,8 +23,8 @@ class MyGame(arcade.Window):
     with your own code. Don't leave 'pass' in this program.
     """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         arcade.set_background_color(arcade.color.AMAZON)
 
@@ -89,7 +90,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    game = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    game = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     game.setup()
     arcade.run()
 

--- a/arcade/examples/starting_template_simple.py
+++ b/arcade/examples/starting_template_simple.py
@@ -1,7 +1,17 @@
+"""
+Starting Template Simple
+
+Once you have learned how to use classes, you can begin your program with this
+template.
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.starting_template_simple
+"""
 import arcade
 
 SCREEN_WIDTH = 500
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Starting Template Simple"
 
 
 class MyGame(arcade.Window):
@@ -9,8 +19,8 @@ class MyGame(arcade.Window):
     Main application class.
     """
 
-    def __init__(self, width, height):
-        super().__init__(width, height)
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
 
         arcade.set_background_color(arcade.color.WHITE)
 
@@ -34,7 +44,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Main method """
-    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    window = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     window.setup()
     arcade.run()
 

--- a/arcade/examples/stress_sprite_list.py
+++ b/arcade/examples/stress_sprite_list.py
@@ -1,10 +1,10 @@
 """
-Sprite List Stress Test
+SpriteList Stress Test
 
 Simple program using SpriteList.
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.sprite_collect_coins
+python -m arcade.examples.stress_sprite_list
 """
 
 import random
@@ -24,7 +24,7 @@ METEOR_COUNT = 500
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
-
+SCREEN_TITLE = "SpriteList Stress Test"
 
 
 class FPSCounter:
@@ -48,7 +48,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "SpriteList Stress Test")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/stress_test_collision.py
+++ b/arcade/examples/stress_test_collision.py
@@ -1,12 +1,12 @@
 """
-Sprite Stress Test
+Sprite Collision Stress Test
 
 Simple program to test how fast we can draw sprites that aren't moving
 
 Artwork from http://kenney.nl
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.stress_test_draw_simple
+python -m arcade.examples.stress_test_collision
 """
 
 import random
@@ -24,6 +24,7 @@ SPRITE_SCALING_PLAYER = 1
 
 SCREEN_WIDTH = 1200
 SCREEN_HEIGHT = 700
+SCREEN_TITLE = "Sprite Collision Stress Test"
 
 
 class MyGame(arcade.Window):
@@ -32,7 +33,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Sprite Example")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/stress_test_draw_moving.py
+++ b/arcade/examples/stress_test_draw_moving.py
@@ -1,12 +1,12 @@
 """
-Sprite Stress Test
+Moving Sprite Stress Test
 
-Simple program to test how fast we can draw sprites that aren't moving
+Simple program to test how fast we can draw sprites that are moving
 
 Artwork from http://kenney.nl
 
 If Python and Arcade are installed, this example can be run from the command line with:
-python -m arcade.examples.stress_test_draw_simple
+python -m arcade.examples.stress_test_draw_moving
 """
 
 import random
@@ -26,6 +26,7 @@ COIN_COUNT_INCREMENT = 100
 
 SCREEN_WIDTH = 1800
 SCREEN_HEIGHT = 1000
+SCREEN_TITLE = "Moving Sprite Stress Test"
 
 
 class FPSCounter:
@@ -62,7 +63,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Moving Sprite Stress Test")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/stress_test_draw_simple.py
+++ b/arcade/examples/stress_test_draw_simple.py
@@ -24,6 +24,7 @@ COIN_COUNT_INCREMENT = 15000
 
 SCREEN_WIDTH = 1800
 SCREEN_HEIGHT = 1000
+SCREEN_TITLE = "Static Sprite Stress Test"
 
 
 class FPSCounter:
@@ -51,7 +52,7 @@ class MyGame(arcade.Window):
     def __init__(self):
         """ Initializer """
         # Call the parent class initializer
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Static Sprite Stress Test")
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
 
         # Set the working directory (where we expect to find files) to the same
         # directory this .py file is in. You can leave this out of your own

--- a/arcade/examples/t_2.py
+++ b/arcade/examples/t_2.py
@@ -4,7 +4,7 @@ class MyGame(arcade.Window):
     """ Our custom Window Class"""
 
     def __init__(self):
-        super().__init__(800, 600, "Moving Sprite Stress Test")
+        super().__init__(800, 600, "t_2")
 
         self.coin_list = arcade.SpriteList()
 

--- a/arcade/examples/test.py
+++ b/arcade/examples/test.py
@@ -1,5 +1,8 @@
 """This is an example on how the autogeometry can be used for deformable
 terrain.
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.test
 """
 __docformat__ = "reStructuredText"
 

--- a/arcade/examples/tetris.py
+++ b/arcade/examples/tetris.py
@@ -4,6 +4,8 @@ Tetris
 Tetris clone, with some ideas from silvasur's code:
 https://gist.github.com/silvasur/565419/d9de6a84e7da000797ac681976442073045c74a4
 
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.tetris
 """
 import arcade
 import random
@@ -24,6 +26,7 @@ MARGIN = 5
 # Do the math to figure out our screen dimensions
 SCREEN_WIDTH = (WIDTH + MARGIN) * COLUMN_COUNT + MARGIN
 SCREEN_HEIGHT = (HEIGHT + MARGIN) * ROW_COUNT + MARGIN
+SCREEN_TITLE = "Tetris"
 
 colors = [
           (0,   0,   0  ),
@@ -117,10 +120,10 @@ def new_board():
 class MyGame(arcade.Window):
     """ Main application class. """
 
-    def __init__(self, width, height):
+    def __init__(self, width, height, title):
         """ Set up the application. """
 
-        super().__init__(width, height)
+        super().__init__(width, height, title)
 
         arcade.set_background_color(arcade.color.WHITE)
 
@@ -262,7 +265,7 @@ class MyGame(arcade.Window):
 
 def main():
     """ Create the game window, setup, run """
-    my_game = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT)
+    my_game = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
     my_game.setup()
     arcade.run()
 

--- a/arcade/examples/timer.py
+++ b/arcade/examples/timer.py
@@ -9,6 +9,7 @@ import arcade
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Timer Example"
 
 
 class MyGame(arcade.Window):
@@ -17,7 +18,7 @@ class MyGame(arcade.Window):
     """
 
     def __init__(self):
-        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT)
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
         self.total_time = 0.0
 
     def setup(self):


### PR DESCRIPTION
While going through the example programs for the first time, I noticed some typos, copy/paste errors, and inconsistencies in the example programs. So, I did a quick pass to make things a bit more consistent.

Also, as I was looking at the example code, I threw together a quick script in `arcade/examples/run_all_examples.py` that will run each file in arcade/examples.  I personally used it to quickly view each example, but there might be some benefit to the community to be able to run this as a sort of semi-automated regression test.

Changes:
* Ensured each example had a correct/unique title on arcade.Window
* Ensured each example had a `python -m` commands in the docstring and that it was correct
* Fixed obvious typos/inconsistencies I found in the docs
* Fixed simple bugs in some broken examples so that they would run with the library found on master
* Note: there are still a handful of examples that seem broken (ex: `arcade/examples/pinball.py`) but they will probably take more effort to fix.