### PR TITLE
Minor fixes to documentation rendering (#316)

### DIFF
--- a/arcade/buffered_draw_commands.py
+++ b/arcade/buffered_draw_commands.py
@@ -1,5 +1,5 @@
 """
-Drawing commands that use the VBOs.
+Drawing commands that use vertex buffer objects (VBOs).
 
 This module contains commands for basic graphics drawing commands,
 but uses Vertex Buffer Objects. This keeps the vertices loaded on

--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -1325,8 +1325,11 @@ def get_image(x=0, y=0, width=None, height=None):
     Get an image from the screen.
     You can save the image like:
 
-    image = get_image()
-    image.save('screenshot.png', 'PNG')
+    .. highlight:: python
+    .. code-block:: python
+
+        image = get_image()
+        image.save('screenshot.png', 'PNG')
     """
 
     # Get the dimensions

--- a/arcade/window_commands.py
+++ b/arcade/window_commands.py
@@ -42,17 +42,19 @@ def create_orthogonal_projection(
         dtype=None
 ):
     """Creates an orthogonal projection matrix.
+
     :param float left: The left of the near plane relative to the plane's centre.
     :param float right: The right of the near plane relative to the plane's centre.
     :param float top: The top of the near plane relative to the plane's centre.
     :param float bottom: The bottom of the near plane relative to the plane's centre.
     :param float near: The distance of the near plane from the camera's origin.
-    It is recommended that the near plane is set to 1.0 or above to avoid
-    rendering issues at close range.
+                       It is recommended that the near plane is set to 1.0 or above to avoid
+                       rendering issues at close range.
     :param float far: The distance of the far plane from the camera's origin.
     :param dtype:
     :rtype: numpy.array
     :return: A projection matrix representing the specified orthogonal perspective.
+
     .. seealso:: http://msdn.microsoft.com/en-us/library/dd373965(v=vs.85).aspx
     """
 

--- a/doc/arcade.rst
+++ b/doc/arcade.rst
@@ -8,6 +8,8 @@ for the Python Arcade library.
 
 For example code, see :ref:`example-code`.
 
+.. contents:: Table of Contents
+
 Submodules
 ----------
 

--- a/doc/examples/index.rst
+++ b/doc/examples/index.rst
@@ -492,7 +492,7 @@ Other
 
    :ref:`asteroid_smasher`
 
-.. figure:: thumbs/gameshell1.jpg
+.. figure:: gameshell1.jpg
    :figwidth: 170px
 
    :ref:`gameshell`

--- a/doc/preprocess_files.py
+++ b/doc/preprocess_files.py
@@ -101,6 +101,8 @@ def main():
     output_file.write("Quick API Index\n")
     output_file.write("===============\n")
     output_file.write("\n")
+    output_file.write(".. contents:: Table of Contents\n")
+    output_file.write("\n")
 
     output_file.write("Window Module\n")
     output_file.write("-------------\n")


### PR DESCRIPTION
* Fix a few minor, isolated documentation rendering issues (code block, function arguments)
* Fixed broken path to gameshell.jpg
* Add table of contents to API and Quick API pages
* Get rid of some `make doc` warnings