### PR TITLE
Add particle systems and supporting example scripts #333

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -16,10 +16,14 @@ from arcade import color
 from arcade import key
 from arcade.application import *
 from arcade.arcade_types import *
+from arcade.utils import *
 from arcade.draw_commands import *
 from arcade.buffered_draw_commands import *
 from arcade.geometry import *
 from arcade.physics_engines import *
+from arcade.emitter import *
+from arcade.emitter_simple import *
+from arcade.particle import *
 from arcade.sound import *
 from arcade.sprite import *
 from arcade.sprite_list import *
@@ -31,3 +35,4 @@ from arcade.isometric import *
 from arcade.text import draw_text
 from arcade.text import create_text
 from arcade.text import render_text
+from arcade.examples.frametime_plotter import *

--- a/arcade/emitter.py
+++ b/arcade/emitter.py
@@ -1,0 +1,178 @@
+"""
+Emitter - Invisible object that determines when Particles are emitted, actually emits them, and manages them over their lifetime
+"""
+
+import arcade
+from arcade.particle import Particle
+from pymunk import Vec2d
+from typing import Callable
+
+
+##########
+class EmitController:
+    """Base class for how a client configure the rate at which an Emitter emits Particles
+
+    Subclasses allow the client to control the rate and duration of emitting"""
+    def how_many(self, delta_time: float, current_particle_count: int) -> int:
+        raise NotImplemented("EmitterRate.how_many must be implemented")
+
+    def is_complete(self) -> bool:
+        raise NotImplemented("EmitterRate.is_complete must be implemented")
+
+
+class EmitBurst(EmitController):
+    """Used to configure an Emitter to emit particles in one burst"""
+    def __init__(self, count: int):
+        self._is_complete = False
+        self._count = count
+
+    def how_many(self, delta_time: float, current_particle_count: int) -> int:
+        if not self._is_complete:
+            self._is_complete = True
+            return self._count
+        return 0
+
+    def is_complete(self) -> bool:
+        return True
+
+
+class EmitMaintainCount(EmitController):
+    """Used to configure an Emitter so it emits particles so that the given count is always maintained"""
+    def __init__(self, particle_count: int):
+        self._target_count = particle_count
+
+    def how_many(self, delta_time: float, current_particle_count: int) -> int:
+        return self._target_count - current_particle_count
+
+    def is_complete(self) -> bool:
+        return False
+
+
+class EmitInterval(EmitController):
+    """Base class used by subclasses that are used to configure an Emitter to have a constant rate of emitting. Will emit indefinitely."""
+    def __init__(self, emit_interval: float):
+        self._emit_interval = emit_interval
+        self._carryover_time = 0.0
+
+    def how_many(self, delta_time: float, current_particle_count: int) -> int:
+        self._carryover_time += delta_time
+        emit_count = 0
+        while self._carryover_time >= self._emit_interval:
+            self._carryover_time -= self._emit_interval
+            emit_count += 1
+        return emit_count
+
+    def is_complete(self) -> bool:
+        return False
+
+
+class EmitterIntervalWithCount(EmitInterval):
+    """Used to configure an Emitter so it emits particles at the given interval, ending after emitting a given number of particles"""
+    def __init__(self, emit_interval: float, particle_count: int):
+        super().__init__(emit_interval)
+        self._count_remaining = particle_count
+
+    def how_many(self, delta_time: float, current_particle_count: int) -> int:
+        proposed_count = super().how_many(delta_time, current_particle_count)
+        actual_count = min(proposed_count, self._count_remaining)
+        self._count_remaining -= actual_count
+        return actual_count
+
+    def is_complete(self) -> bool:
+        return self._count_remaining <= 0
+
+
+class EmitterIntervalWithTime(EmitInterval):
+    """Useed to configure an Emitter so it emits particles at the given interval, ending after given number of seconds"""
+    def __init__(self, emit_interval: float, lifetime: float):
+        super().__init__(emit_interval)
+        self._lifetime = lifetime
+
+    def how_many(self, delta_time: float, current_particle_count: int) -> int:
+        if self._lifetime <= 0.0:
+            return 0
+        self._lifetime -= delta_time
+        return super().how_many(delta_time, current_particle_count)
+
+    def is_complete(self) -> bool:
+        return self._lifetime <= 0
+
+
+
+########## Emitter
+class Emitter:
+    """Emits and manages Particles over their lifetime.  The foundational class in a particle system."""
+    def __init__(
+        self,
+        pos: Vec2d,
+        emit_controller: EmitController,
+        particle_factory: Callable[["Emitter"], Particle],
+        vel: Vec2d = None,
+        emit_done_cb: Callable[["Emitter"], None] = None,
+        reap_cb: Callable[[], None] = None
+    ):
+        # Note Self-reference with type annotations: https://www.python.org/dev/peps/pep-0484/#the-problem-of-forward-declarations
+        if vel is None:
+            self.change_x = 0.0
+            self.change_y = 0.0
+        else:
+            self.change_x = vel.x
+            self.change_y = vel.y
+
+        self.center_x = pos.x
+        self.center_y = pos.y
+        self.angle = 0.0
+        self.change_angle = 0.0
+        self.rate_factory = emit_controller
+        self.particle_factory = particle_factory
+        self._emit_done_cb = emit_done_cb
+        self._reap_cb = reap_cb
+        self._particles = arcade.SpriteList(use_spatial_hash=False)
+
+    def _emit(self):
+        """Emit one particle. A particle's position is treated relative to the position of the emitter"""
+        p = self.particle_factory(self)
+        p.center_x = self.center_x + p.center_x
+        p.center_y = self.center_y + p.center_y
+        vel = Vec2d(p.change_x, p.change_y).rotated_degrees(self.angle)
+        p.change_x = vel.x
+        p.change_y = vel.y
+        self._particles.append(p)
+
+    def get_count(self):
+        return len(self._particles)
+
+    def get_pos(self) -> Vec2d:
+        """Get position of emitter as a Vec2d"""
+        # TODO: should this be a property so a method call isn't needed?
+        return Vec2d(self.center_x, self.center_y)
+
+    def update(self):
+        # update emitter
+        self.center_x += self.change_x
+        self.center_y += self.change_y
+        self.angle += self.change_angle
+
+        # update particles
+        emit_count = self.rate_factory.how_many(1 / 60, len(self._particles))
+        for _ in range(emit_count):
+            self._emit()
+        self._particles.update()
+        particles_to_reap = [p for p in self._particles if p.can_reap()]
+        for dead_particle in particles_to_reap:
+            dead_particle.kill()
+
+    def draw(self):
+        self._particles.draw()
+
+    def can_reap(self):
+        """Determine if Emitter can be deleted"""
+        is_emit_complete = self.rate_factory.is_complete()
+        can_reap = is_emit_complete and len(self._particles) <= 0
+        if is_emit_complete and self._emit_done_cb:
+            self._emit_done_cb(self)
+            self._emit_done_cb = None
+        if can_reap and self._reap_cb:
+            self._reap_cb()
+            self._reap_cb = None
+        return can_reap

--- a/arcade/emitter_simple.py
+++ b/arcade/emitter_simple.py
@@ -1,0 +1,61 @@
+"""
+Convenience functions that provide a much simpler interface to Emitters and Particles.
+
+These trade away some flexibility in favor of simplicity to allow beginners to start using particle systems.
+"""
+
+import arcade
+import random
+from typing import List
+from pymunk import Vec2d
+
+def make_burst_emitter(
+        pos: Vec2d,
+        filenames_and_textures: List[str],  # Also supports Texture objects in the List
+        particle_count: int,
+        particle_speed: float,
+        particle_lifetime_min: float,
+        particle_lifetime_max: float,
+        particle_scale: float = 1.0,
+        fade_particles: bool = True
+    ):
+    """Returns an emitter that emits all of its particles at once"""
+    particle_factory = arcade.LifetimeParticle
+    if fade_particles:
+        particle_factory = arcade.FadeParticle
+    return arcade.Emitter(
+        pos=pos,
+        emit_controller=arcade.EmitBurst(particle_count),
+        particle_factory=lambda emitter: particle_factory(
+            filename_or_texture=random.choice(filenames_and_textures),
+            vel=arcade.rand_in_circle(Vec2d.zero(), particle_speed),
+            lifetime=random.uniform(particle_lifetime_min, particle_lifetime_max),
+            scale=particle_scale
+        )
+    )
+
+def make_interval_emitter(
+        pos: Vec2d,
+        filenames_and_textures: List[str], # Also supports Texture objects in the List
+        emit_interval: float,
+        emit_duration: float,
+        particle_speed: float,
+        particle_lifetime_min: float,
+        particle_lifetime_max: float,
+        particle_scale: float = 1.0,
+        fade_particles: bool = True
+    ):
+    """Returns an emitter that emits its particles at a constant rate for a given amount of time"""
+    particle_factory = arcade.LifetimeParticle
+    if fade_particles:
+        particle_factory = arcade.FadeParticle
+    return arcade.Emitter(
+        pos=pos,
+        emit_controller=arcade.EmitterIntervalWithTime(emit_interval, emit_duration),
+        particle_factory=lambda emitter: particle_factory(
+            filename_or_texture=random.choice(filenames_and_textures),
+            vel=arcade.rand_on_circle(Vec2d.zero(), particle_speed),
+            lifetime=random.uniform(particle_lifetime_min, particle_lifetime_max),
+            scale=particle_scale
+        )
+    )

--- a/arcade/examples/frametime_plotter.py
+++ b/arcade/examples/frametime_plotter.py
@@ -1,0 +1,46 @@
+"""
+Helper class to track length of time taken for each frame and draw a graph when application exits.
+Also able to add events at arbitrary times across the graph.
+"""
+import matplotlib.pyplot as plt
+import statistics
+
+class FrametimePlotter:
+    EVENT_POINT_Y = -0.05
+    EVENT_MSG_Y = -0.045
+
+    def __init__(self):
+        self.times = []
+        self.events = []
+
+    def add_event(self, event_msg):
+        self.events.append( (len(self.times), event_msg))
+
+    def end_frame(self, time_delta):
+        self.times.append(time_delta)
+
+    def _show_stats(self):
+        print("Min   : {:.5f}".format(min(self.times)))
+        print("Max   : {:.5f}".format(max(self.times)))
+        print("Avg   : {:.5f}".format(statistics.mean(self.times)))
+        print("Median: {:.5f}".format(statistics.median(self.times)))
+        try:
+            print("Mode  : {:.5f}".format(statistics.mode(self.times)))
+        except statistics.StatisticsError as e:
+            print("Mode  : {}".format(e))
+        print("StdDev: {:.5f}".format(statistics.stdev(self.times)))
+
+    def show(self):
+        self._show_stats()
+        frame_idxs = range(0, len(self.times))
+        event_idxs = [e[0] for e in self.events]
+        event_point_y = [self.EVENT_POINT_Y] * len(self.events)
+        plt.figure("Frame durations", figsize=(8, 6))
+        plt.plot(frame_idxs, self.times, event_idxs, event_point_y, "k|")
+        plt.xlabel("frames")
+        plt.ylabel("frame duration")
+        plt.ylim(self.EVENT_POINT_Y-0.005, 0.5)
+        plt.tight_layout()
+        for frame_idx, msg in self.events:
+            plt.text(frame_idx, self.EVENT_MSG_Y, msg, horizontalalignment="center", verticalalignment="bottom", size="smaller", rotation="vertical")
+        plt.show()

--- a/arcade/examples/particle_fireworks.py
+++ b/arcade/examples/particle_fireworks.py
@@ -1,0 +1,359 @@
+"""
+Particle Fireworks
+
+Use a fireworks display to demonstrate "real-world" uses of Emitters and Particles
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.sprite_list_particle_fireworks
+"""
+import arcade
+import os
+import random
+import pyglet
+from pymunk import Vec2d
+
+SCREEN_WIDTH = 800
+SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Particle based fireworks"
+LAUNCH_INTERVAL_MIN = 1.5
+LAUNCH_INTERVAL_MAX = 2.5
+TEXTURE = "images/pool_cue_ball.png"
+RAINBOW_COLORS = (
+    arcade.color.ELECTRIC_CRIMSON,
+    arcade.color.FLUORESCENT_ORANGE,
+    arcade.color.ELECTRIC_YELLOW,
+    arcade.color.ELECTRIC_GREEN,
+    arcade.color.ELECTRIC_CYAN,
+    arcade.color.MEDIUM_ELECTRIC_BLUE,
+    arcade.color.ELECTRIC_INDIGO,
+    arcade.color.ELECTRIC_PURPLE,
+)
+SPARK_TEXTURES = [arcade.make_circle_texture(15, clr) for clr in RAINBOW_COLORS]
+SPARK_PAIRS = [
+    [SPARK_TEXTURES[0], SPARK_TEXTURES[3]],
+    [SPARK_TEXTURES[1], SPARK_TEXTURES[5]],
+    [SPARK_TEXTURES[7], SPARK_TEXTURES[2]],
+]
+ROCKET_SMOKE_TEXTURE = arcade.make_soft_circle_texture(15, arcade.color.GRAY)
+PUFF_TEXTURE = arcade.make_soft_circle_texture(80, (40, 40, 40))
+FLASH_TEXTURE = arcade.make_soft_circle_texture(70, (128, 128, 90))
+CLOUD_TEXTURES = [
+    arcade.make_soft_circle_texture(50, arcade.color.WHITE),
+    arcade.make_soft_circle_texture(50, arcade.color.LIGHT_GRAY),
+    arcade.make_soft_circle_texture(50, arcade.color.LIGHT_BLUE),
+]
+STAR_TEXTURES = [
+    arcade.make_soft_circle_texture(6, arcade.color.WHITE),
+    arcade.make_soft_circle_texture(6, arcade.color.PASTEL_YELLOW),
+]
+SPINNER_HEIGHT=75
+
+
+def make_spinner():
+    spinner = arcade.Emitter(
+        pos=Vec2d(SCREEN_WIDTH / 2, SPINNER_HEIGHT - 5),
+        emit_controller=arcade.EmitterIntervalWithTime(0.025, 2.0),
+        particle_factory=lambda emitter: arcade.FadeParticle(
+            filename_or_texture=random.choice(STAR_TEXTURES),
+            vel=Vec2d(0, 6.0),
+            lifetime=0.2
+        )
+    )
+    spinner.change_angle = 16.28
+    return spinner
+
+def make_rocket(emit_done_cb):
+    """Emitter that displays the smoke trail as the firework shell climbs into the sky"""
+    rocket = RocketEmitter(
+        pos=Vec2d(random.uniform(100, SCREEN_WIDTH - 100), 25),
+        emit_controller=arcade.EmitterIntervalWithTime(0.04, 2.0),
+        particle_factory=lambda emitter: arcade.FadeParticle(
+            filename_or_texture=ROCKET_SMOKE_TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), 0.08),
+            scale=0.5,
+            lifetime=random.uniform(1.0, 1.5),
+            start_alpha=100,
+            end_alpha=0,
+            mutation_callback=rocket_smoke_mutator
+        ),
+        emit_done_cb=emit_done_cb
+    )
+    rocket.change_x = random.uniform(-1.0, 1.0)
+    rocket.change_y = random.uniform(5.0, 7.25)
+    return rocket
+
+def make_flash(prev_emitter):
+    """Return emitter that displays the brief flash when a firework shell explodes"""
+    return arcade.Emitter(
+        pos=prev_emitter.get_pos(),
+        emit_controller=arcade.EmitBurst(3),
+        particle_factory=lambda emitter: arcade.FadeParticle(
+            filename_or_texture=FLASH_TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), 3.5),
+            lifetime=0.15
+        )
+    )
+
+def make_puff(prev_emitter):
+    """Return emitter that generates the subtle smoke cloud left after a firework shell explodes"""
+    return arcade.Emitter(
+        pos=prev_emitter.get_pos(),
+        emit_controller=arcade.EmitBurst(4),
+        particle_factory=lambda emitter: arcade.FadeParticle(
+            filename_or_texture=PUFF_TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), 0.4) + Vec2d(0.3, 0.0),
+            lifetime=4.0
+        )
+    )
+
+
+class AnimatedAlphaParticle(arcade.LifetimeParticle):
+    """A custom particle that animates between three different alpha levels"""
+    def __init__(
+        self,
+        filename_or_texture: str,
+        vel: Vec2d,
+        start_alpha: int = 0,
+        duration1: float = 1.0,
+        mid_alpha: int = 255,
+        duration2: float = 1.0,
+        end_alpha: int = 0,
+        pos: Vec2d = None,
+        angle: float = 0,
+        change_angle: float = 0,
+        scale: float = 1.0,
+        mutation_callback=None,
+    ):
+        super().__init__(filename_or_texture, vel, duration1 + duration2, pos, angle, change_angle, scale, start_alpha, mutation_callback)
+        self.start_alpha = start_alpha
+        self.in_duration = duration1
+        self.mid_alpha = mid_alpha
+        self.out_duration = duration2
+        self.end_alpha = end_alpha
+
+    def update(self):
+        super().update()
+        if self.lifetime_elapsed <= self.in_duration:
+            u = self.lifetime_elapsed / self.in_duration
+            self.alpha = arcade.utils.lerp(self.start_alpha, self.mid_alpha, u)
+        else:
+            u = (self.lifetime_elapsed - self.in_duration) / self.out_duration
+            self.alpha = arcade.utils.lerp(self.mid_alpha, self.end_alpha, u)
+
+
+class RocketEmitter(arcade.Emitter):
+    """Custom emitter class to add gravity to the emitter to represent gravity on the firework shell"""
+    def update(self):
+        super().update()
+        # gravity
+        self.change_y += -0.05
+
+
+class FireworksApp(arcade.Window):
+    def __init__(self):
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
+
+        # Set the working directory (where we expect to find files) to the same
+        # directory this .py file is in. You can leave this out of your own
+        # code, but it is needed to easily run the examples using "python -m"
+        # as mentioned at the top of this program.
+        file_path = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(file_path)
+
+        arcade.set_background_color(arcade.color.BLACK)
+        self.emitters = []
+        self.frametime_plotter = arcade.FrametimePlotter()
+
+        self.launch_firework(0)
+        arcade.schedule(self.launch_spinner, 4.0)
+
+        stars = arcade.Emitter(
+            pos=Vec2d.zero(),
+            emit_controller=arcade.EmitMaintainCount(20),
+            particle_factory=lambda emitter: AnimatedAlphaParticle(
+                filename_or_texture=random.choice(STAR_TEXTURES),
+                vel=Vec2d.zero(),
+                start_alpha=0,
+                duration1=random.uniform(2.0, 6.0),
+                mid_alpha=128,
+                duration2=random.uniform(2.0, 6.0),
+                end_alpha=0,
+                pos=arcade.rand_in_rect(Vec2d.zero(), SCREEN_WIDTH, SCREEN_HEIGHT)
+            )
+        )
+        self.emitters.append(stars)
+
+        self.cloud = arcade.Emitter(
+            pos=Vec2d(50, 500),
+            vel=Vec2d(0.15, 0),
+            emit_controller=arcade.EmitMaintainCount(60),
+            particle_factory=lambda emitter: AnimatedAlphaParticle(
+                filename_or_texture=random.choice(CLOUD_TEXTURES),
+                vel=arcade.rand_in_circle(Vec2d.zero(), 0.04) + Vec2d(0.1, 0),
+                start_alpha=0,
+                duration1=random.uniform(5.0, 10.0),
+                mid_alpha=255,
+                duration2=random.uniform(5.0, 10.0),
+                end_alpha=0,
+                pos=arcade.rand_in_circle(Vec2d.zero(), 50)
+            )
+        )
+        self.emitters.append(self.cloud)
+
+    def launch_firework(self, delta_time):
+        self.frametime_plotter.add_event("launch")
+        launchers = (
+            self.launch_random_firework,
+            self.launch_ringed_firework,
+            self.launch_sparkle_firework,
+        )
+        random.choice(launchers)(delta_time)
+        pyglet.clock.schedule_once(self.launch_firework, random.uniform(LAUNCH_INTERVAL_MIN, LAUNCH_INTERVAL_MAX))
+
+    def launch_random_firework(self, delta_time):
+        """Simple firework that explodes in a random color"""
+        rocket = make_rocket(self.explode_firework)
+        self.emitters.append(rocket)
+
+    def launch_ringed_firework(self, delta_time):
+        """"Firework that has a basic explosion and a ring of sparks of a different color"""
+        rocket = make_rocket(self.explode_ringed_firework)
+        self.emitters.append(rocket)
+
+    def launch_sparkle_firework(self, delta_time):
+        """Firework which has sparks that sparkle"""
+        rocket = make_rocket(self.explode_sparkle_firework)
+        self.emitters.append(rocket)
+
+    def launch_spinner(self, delta_time):
+        """Start the spinner that throws sparks"""
+        spinner1 = make_spinner()
+        spinner2 = make_spinner()
+        spinner2.angle = 180
+        self.emitters.append(spinner1)
+        self.emitters.append(spinner2)
+
+    def explode_firework(self, prev_emitter):
+        """Actions that happen when a firework shell explodes, resulting in a typical firework"""
+        self.emitters.append(make_puff(prev_emitter))
+        self.emitters.append(make_flash(prev_emitter))
+
+        spark_texture = random.choice(SPARK_TEXTURES)
+        sparks = arcade.Emitter(
+            pos=prev_emitter.get_pos(),
+            emit_controller=arcade.EmitBurst(random.randint(30, 40)),
+            particle_factory=lambda emitter: arcade.FadeParticle(
+                filename_or_texture=spark_texture,
+                vel=arcade.rand_in_circle(Vec2d.zero(), 9.0),
+                lifetime=random.uniform(0.5, 1.2),
+                mutation_callback=firework_spark_mutator
+            )
+        )
+        self.emitters.append(sparks)
+
+    def explode_ringed_firework(self, prev_emitter):
+        """Actions that happen when a firework shell explodes, resulting in a ringed firework"""
+        self.emitters.append(make_puff(prev_emitter))
+        self.emitters.append(make_flash(prev_emitter))
+
+        spark_texture, ring_texture = random.choice(SPARK_PAIRS)
+        sparks = arcade.Emitter(
+            pos=prev_emitter.get_pos(),
+            emit_controller=arcade.EmitBurst(25),
+            particle_factory=lambda emitter: arcade.FadeParticle(
+                filename_or_texture=spark_texture,
+                vel=arcade.rand_in_circle(Vec2d.zero(), 8.0),
+                lifetime=random.uniform(0.55, 0.8),
+                mutation_callback=firework_spark_mutator
+            )
+        )
+        self.emitters.append(sparks)
+
+        ring = arcade.Emitter(
+            pos=prev_emitter.get_pos(),
+            emit_controller=arcade.EmitBurst(20),
+            particle_factory=lambda emitter: arcade.FadeParticle(
+                filename_or_texture=ring_texture,
+                vel=arcade.rand_on_circle(Vec2d.zero(), 5.0) + arcade.rand_in_circle(Vec2d.zero(), 0.25),
+                lifetime=random.uniform(1.0, 1.6),
+                mutation_callback=firework_spark_mutator
+            )
+        )
+        self.emitters.append(ring)
+
+    def explode_sparkle_firework(self, prev_emitter):
+        """Actions that happen when a firework shell explodes, resulting in a sparkling firework"""
+        self.emitters.append(make_puff(prev_emitter))
+        self.emitters.append(make_flash(prev_emitter))
+
+        spark_texture = random.choice(SPARK_TEXTURES)
+        sparks = arcade.Emitter(
+            pos=prev_emitter.get_pos(),
+            emit_controller=arcade.EmitBurst(random.randint(30, 40)),
+            particle_factory=lambda emitter: AnimatedAlphaParticle(
+                filename_or_texture=spark_texture,
+                vel=arcade.rand_in_circle(Vec2d.zero(), 9.0),
+                start_alpha=255,
+                duration1=random.uniform(0.6, 1.0),
+                mid_alpha=0,
+                duration2=random.uniform(0.1, 0.2),
+                end_alpha=255,
+                mutation_callback=firework_spark_mutator
+            )
+        )
+        self.emitters.append(sparks)
+
+    def update(self, delta_time):
+        # prevent list from being mutated (often by callbacks) while iterating over it
+        emitters_to_update = self.emitters.copy()
+        # update cloud
+        if self.cloud.center_x > SCREEN_WIDTH:
+            self.cloud.center_x = 0
+        # update
+        for e in emitters_to_update:
+            e.update()
+        # remove emitters that can be reaped
+        to_del = [e for e in emitters_to_update if e.can_reap()]
+        for e in to_del:
+            self.emitters.remove(e)
+        self.frametime_plotter.end_frame(delta_time)
+
+    def on_draw(self):
+        arcade.start_render()
+        for e in self.emitters:
+            e.draw()
+        arcade.draw_lrtb_rectangle_filled(0, SCREEN_WIDTH, 25, 0, arcade.color.DARK_GREEN)
+        mid = SCREEN_WIDTH / 2
+        arcade.draw_lrtb_rectangle_filled(mid-2, mid+2, SPINNER_HEIGHT, 10, arcade.color.DARK_BROWN)
+
+        counts = [e.get_count() for e in self.emitters]
+        arcade.draw_text("Emitter/Particle counts: {} / {}".format(len(self.emitters), sum(counts)),
+                         10, 10,
+                         arcade.color.WHITE, 12)
+
+    def on_key_press(self, key, modifiers):
+        if key == arcade.key.ESCAPE:
+            arcade.close_window()
+
+
+def firework_spark_mutator(emitter: arcade.Emitter):
+    """mutation_callback shared by all fireworks sparks"""
+    # gravity
+    emitter.change_y += -0.03
+    # drag
+    emitter.change_x *= 0.92
+    emitter.change_y *= 0.92
+
+def rocket_smoke_mutator(emitter: arcade.Emitter):
+    emitter.scale = arcade.lerp(0.5, 3.0, emitter.lifetime_elapsed/emitter.lifetime_original)
+    # A Sprite's scale doesn't affect generated textures (ex: make_soft_circle_texture) or scale being animated over time.
+    # The fix below is copied from Sprite.update_animation().
+    # Bug may have been recorded here: https://github.com/pvcraven/arcade/issues/331
+    emitter.width = emitter._texture.width * emitter.scale
+    emitter.height = emitter._texture.height * emitter.scale
+
+
+if __name__ == "__main__":
+    app = FireworksApp()
+    arcade.run()
+    app.frametime_plotter.show()

--- a/arcade/examples/particle_systems.py
+++ b/arcade/examples/particle_systems.py
@@ -1,0 +1,740 @@
+"""
+Particle Systems
+
+Demonstrate how to use the Emitter and Particle classes to create particle systems.
+
+Demonstrate the different effects possible with Emitter's and Particle's by showing
+a number of different emitters in sequence, with each example often varying just one
+setting from the previous example.
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.sprite_list_particle_systems
+"""
+import arcade
+import pyglet
+from pymunk import Vec2d
+import os
+import random
+import math
+
+SCREEN_WIDTH = 800
+SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Particle System Examples"
+QUIET_BETWEEN_SPAWNS = 0.25 # time between spawning another particle system
+EMITTER_TIMEOUT = 10*60
+CENTER_POS = Vec2d(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2)
+BURST_PARTICLE_COUNT = 500
+TEXTURE = "images/pool_cue_ball.png"
+TEXTURE2 = "images/playerShip3_orange.png"
+TEXTURE3 = "images/bumper.png"
+TEXTURE4 = "images/wormGreen.png"
+TEXTURE5 = "images/meteorGrey_med1.png"
+TEXTURE6 = "images/character.png"
+TEXTURE7 = "images/boxCrate_double.png"
+DEFAULT_SCALE = 0.3
+DEFAULT_ALPHA = 32
+DEFAULT_PARTICLE_LIFETIME = 3.0
+PARTICLE_SPEED_FAST = 1.0
+PARTICLE_SPEED_SLOW = 0.3
+DEFAULT_EMIT_INTERVAL = 0.003
+DEFAULT_EMIT_DURATION = 1.5
+
+
+##### Utils
+def sine_wave(t, min_x, max_x, wavelength):
+    spread = max_x - min_x
+    mid = (max_x + min_x) / 2
+    return (spread / 2) * math.sin( 2 * math.pi * t / wavelength) + mid
+
+
+##### Example emitters
+def emitter_0():
+    """Burst, emit from center, particle with lifetime"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_0.__doc__, e
+
+def emitter_1():
+    """Burst, emit from center, particle lifetime 1.0 seconds"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=1.0,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_1.__doc__, e
+
+def emitter_2():
+    """Burst, emit from center, particle lifetime random in range"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(),PARTICLE_SPEED_FAST),
+            lifetime=random.uniform(DEFAULT_PARTICLE_LIFETIME - 1.0, DEFAULT_PARTICLE_LIFETIME),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_2.__doc__, e
+
+def emitter_3():
+    """Burst, emit in circle"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            pos=arcade.rand_in_circle(Vec2d.zero(), 100),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_3.__doc__, e
+
+def emitter_4():
+    """Burst, emit on circle"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            pos=arcade.rand_on_circle(Vec2d.zero(), 100),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_4.__doc__, e
+
+def emitter_5():
+    """Burst, emit in rectangle"""
+    width, height = 200, 100
+    centering_offset = Vec2d(-width/2, -height/2)
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            pos=arcade.rand_in_rect(centering_offset, width, height),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_5.__doc__, e
+
+def emitter_6():
+    """Burst, emit on line"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            pos=arcade.rand_on_line(Vec2d.zero(), Vec2d(SCREEN_WIDTH, SCREEN_HEIGHT)),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_6.__doc__, e
+
+def emitter_7():
+    """Burst, emit from center, velocity fixed speed around 360 degrees"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT // 4),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_on_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_7.__doc__, e
+
+def emitter_8():
+    """Burst, emit from center, velocity in rectangle"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_rect(Vec2d(-2.0, -2.0), 4.0, 4.0),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            pos=Vec2d.zero(),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_8.__doc__, e
+
+def emitter_9():
+    """Burst, emit from center, velocity in fixed angle and random speed"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT // 4),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_vec_magnitude(45, 1.0, 4.0),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_9.__doc__, e
+
+def emitter_10():
+    """Burst, emit from center, velocity from angle with spread"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT // 4),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_vec_spread_deg(90, 45, 2.0),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_10.__doc__, e
+
+def emitter_11():
+    """Burst, emit from center, velocity along a line"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT // 4),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_on_line(Vec2d(-2, 1), Vec2d(2, 1)),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_11.__doc__, e
+
+def emitter_12():
+    """Infinite emitting w/ eternal particle"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitInterval(0.02),
+        particle_factory=lambda emitter: arcade.EternalParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_12.__doc__, e
+
+def emitter_13():
+    """Interval, emit particle every 0.01 seconds for one second"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_13.__doc__, e
+
+def emitter_14():
+    """Interval, emit from center, particle lifetime 1.0 seconds"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=1.0,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_14.__doc__, e
+
+def emitter_15():
+    """Interval, emit from center, particle lifetime random in range"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=random.uniform( DEFAULT_PARTICLE_LIFETIME - 1.0, DEFAULT_PARTICLE_LIFETIME),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_15.__doc__, e
+
+def emitter_16():
+    """Interval, emit in circle"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            pos=arcade.rand_in_circle(Vec2d.zero(), 100),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_16.__doc__, e
+
+def emitter_17():
+    """Interval, emit on circle"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            pos=arcade.rand_on_circle(Vec2d.zero(), 100),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_17.__doc__, e
+
+def emitter_18():
+    """Interval, emit in rectangle"""
+    width, height = 200, 100
+    centering_offset = Vec2d(-width/2, -height/2)
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            pos=arcade.rand_in_rect(centering_offset, width, height),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_18.__doc__, e
+
+
+
+#### left off formatting here.
+## do auto-remove of angle and change_angle
+def emitter_19():
+    """Interval, emit on line"""
+    e = arcade.Emitter(
+        pos=Vec2d.zero(),
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            pos=arcade.rand_on_line(Vec2d.zero(), Vec2d(SCREEN_WIDTH, SCREEN_HEIGHT)),
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_19.__doc__, e
+
+def emitter_20():
+    """Interval, emit from center, velocity fixed speed around 360 degrees"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_on_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_20.__doc__, e
+
+def emitter_21():
+    """Interval, emit from center, velocity in rectangle"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_rect(Vec2d(-2.0, -2.0), 4.0, 4.0),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_21.__doc__, e
+
+def emitter_22():
+    """Interval, emit from center, velocity in fixed angle and speed"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(0.2, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=Vec2d(1.0, 1.0),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=128
+        )
+    )
+    return emitter_22.__doc__, e
+
+def emitter_23():
+    """Interval, emit from center, velocity in fixed angle and random speed"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 8, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_vec_magnitude(45, 1.0, 4.0),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_23.__doc__, e
+
+def emitter_24():
+    """Interval, emit from center, velocity from angle with spread"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_vec_spread_deg(90, 45, 2.0),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_24.__doc__, e
+
+def emitter_25():
+    """Interval, emit from center, velocity along a line"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_on_line(Vec2d(-2, 1), Vec2d(2, 1)),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_25.__doc__, e
+
+def emitter_26():
+    """Interval, emit particles every 0.4 seconds and stop after emitting 5"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithCount(0.4, 5),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=0.6,
+            alpha=128
+        )
+    )
+    return emitter_26.__doc__, e
+
+def emitter_27():
+    """Maintain a steady count of particles"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitMaintainCount(3),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_on_circle(Vec2d.zero(), 2.0),
+            lifetime=random.uniform(1.0, 3.0),
+        )
+    )
+    return emitter_27.__doc__, e
+
+def emitter_28():
+    """random particle textures"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 5, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=random.choice((TEXTURE, TEXTURE2, TEXTURE3)),
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE
+        )
+    )
+    return emitter_28.__doc__, e
+
+def emitter_29():
+    """random particle scale"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 5, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=random.uniform(0.1, 0.8),
+            alpha=DEFAULT_ALPHA
+        )
+    )
+    return emitter_29.__doc__, e
+
+def emitter_30():
+    """random particle alpha"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 5, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE,
+            alpha=random.uniform(32, 128)
+        )
+    )
+    return emitter_30.__doc__, e
+
+def emitter_31():
+    """Constant particle angle"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 5, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE2,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            angle=45,
+            scale=DEFAULT_SCALE
+        )
+    )
+    return emitter_31.__doc__, e
+
+def emitter_32():
+    """animate particle angle"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 5, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE2,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            change_angle=2,
+            scale=DEFAULT_SCALE
+        )
+    )
+    return emitter_32.__doc__, e
+
+def emitter_33():
+    """Particles that fade over time"""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.FadeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE
+        )
+    )
+    return emitter_33.__doc__, e
+
+def emitter_34():
+    """Dynamically generated textures, burst emitting, fading particles"""
+    textures = [arcade.make_soft_circle_texture(48, p) for p in (arcade.color.GREEN, arcade.color.BLUE_GREEN)]
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
+        particle_factory=lambda emitter: arcade.FadeParticle(
+            filename_or_texture=random.choice(textures),
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            lifetime=DEFAULT_PARTICLE_LIFETIME,
+            scale=DEFAULT_SCALE
+        )
+    )
+    return emitter_34.__doc__, e
+
+def emitter_35():
+    """Use most features"""
+    soft_circle = arcade.make_soft_circle_texture(80, (255, 64, 64))
+    textures = (TEXTURE, TEXTURE2, TEXTURE3, TEXTURE4, TEXTURE5, TEXTURE6, TEXTURE7, soft_circle)
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(0.01, 1.0),
+        particle_factory=lambda emitter: arcade.FadeParticle(
+            filename_or_texture=random.choice(textures),
+            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST * 2),
+            lifetime=random.uniform(1.0, 3.5),
+            angle=random.uniform(0, 360),
+            change_angle=random.uniform(-3, 3),
+            scale=random.uniform(0.1, 0.8)
+        )
+    )
+    return emitter_35.__doc__, e
+
+def emitter_36():
+    """Moving emitter. Particles spawn relative to emitter."""
+    class MovingEmitter(arcade.Emitter):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.elapsed = 0.0
+
+        def update(self):
+            super().update()
+            self.elapsed += 1 / 60
+            self.center_x = sine_wave(self.elapsed, 0, SCREEN_WIDTH, SCREEN_WIDTH / 100)
+            self.center_y = sine_wave(self.elapsed, 0, SCREEN_HEIGHT, SCREEN_HEIGHT / 100)
+
+    e = MovingEmitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitInterval(0.005),
+        particle_factory=lambda emitter: arcade.FadeParticle(
+            filename_or_texture=TEXTURE,
+            vel=arcade.rand_in_circle(Vec2d.zero(), 0.1),
+            lifetime=random.uniform(1.5, 5.5),
+            scale=random.uniform(0.05, 0.2)
+        )
+    )
+    return emitter_36.__doc__, e
+
+def emitter_37():
+    """Rotating emitter. Particles initial velocity is relative to emitter's angle."""
+    e = arcade.Emitter(
+        pos=CENTER_POS,
+        emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
+        particle_factory=lambda emitter: arcade.LifetimeParticle(
+            filename_or_texture=TEXTURE,
+            vel=Vec2d(0.0, 2.0),
+            lifetime=2.0,
+            scale=DEFAULT_SCALE
+        )
+    )
+    e.change_angle = 10.0
+    return emitter_37.__doc__, e
+
+def emitter_38():
+    """Use simple emitter interface to create a burst emitter"""
+    e = arcade.make_burst_emitter(
+        pos=CENTER_POS,
+        filenames_and_textures=(TEXTURE, TEXTURE3, TEXTURE4),
+        particle_count=50,
+        particle_speed=2.5,
+        particle_lifetime_min=1.0,
+        particle_lifetime_max=2.5,
+        particle_scale=0.3,
+        fade_particles=True
+    )
+    return emitter_38.__doc__, e
+
+def emitter_39():
+    """Use simple emitter interface to create an interval emitter"""
+    e = arcade.make_interval_emitter(
+        pos=CENTER_POS,
+        filenames_and_textures=(TEXTURE, TEXTURE3, TEXTURE4),
+        emit_interval=0.01,
+        emit_duration=2.0,
+        particle_speed=1.5,
+        particle_lifetime_min=1.0,
+        particle_lifetime_max=3.0,
+        particle_scale=0.2,
+        fade_particles=True
+    )
+    return emitter_39.__doc__, e
+
+
+class MyGame(arcade.Window):
+    def __init__(self):
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
+
+        # Set the working directory (where we expect to find files) to the same
+        # directory this .py file is in. You can leave this out of your own
+        # code, but it is needed to easily run the examples using "python -m"
+        # as mentioned at the top of this program.
+        file_path = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(file_path)
+
+        arcade.set_background_color(arcade.color.BLACK)
+
+        # collect particle factory functions
+        self.factories = [v for k, v in globals().items() if k.startswith("emitter_")]
+
+        self.emitter_factory_id = -1
+        self.label = None
+        self.emitter = None
+        self.obj = arcade.Sprite("images/bumper.png", 0.2, center_x=0, center_y=15)
+        self.obj.change_x = 3
+        self.frametime_plotter = arcade.FrametimePlotter()
+        pyglet.clock.schedule_once(self.next_emitter, QUIET_BETWEEN_SPAWNS)
+
+    def next_emitter(self, time_delta):
+        self.emitter_factory_id = (self.emitter_factory_id + 1) % len(self.factories)
+        print("Changing emitter to {}".format(self.emitter_factory_id))
+        self.emitter_timeout = 0
+        self.label, self.emitter = self.factories[self.emitter_factory_id]()
+        self.frametime_plotter.add_event("spawn {}".format(self.emitter_factory_id))
+
+    def update(self, delta_time):
+        if self.emitter:
+            self.emitter_timeout += 1
+            self.emitter.update()
+            if self.emitter.can_reap() or self.emitter_timeout > EMITTER_TIMEOUT:
+                self.frametime_plotter.add_event("reap")
+                pyglet.clock.schedule_once(self.next_emitter, QUIET_BETWEEN_SPAWNS)
+                self.emitter = None
+        self.obj.update()
+        if self.obj.center_x > SCREEN_WIDTH:
+            self.obj.center_x = 0
+        self.frametime_plotter.end_frame(delta_time)
+
+    def on_draw(self):
+        arcade.start_render()
+        self.obj.draw()
+        if self.label:
+            arcade.draw_text("#{} {}".format(self.emitter_factory_id, self.label),
+                             SCREEN_WIDTH / 2, SCREEN_HEIGHT - 20,
+                             arcade.color.PALE_GOLD, 20, width=SCREEN_WIDTH, align="center",
+                             anchor_x="center", anchor_y="center")
+        if self.emitter:
+            self.emitter.draw()
+            arcade.draw_text("Particles: " + str(len(self.emitter._particles)), 10, 30, arcade.color.PALE_GOLD, 12)
+
+    def on_key_press(self, key, modifiers):
+        if key == arcade.key.ESCAPE:
+            arcade.close_window()
+
+
+if __name__ == "__main__":
+    game = MyGame()
+    arcade.run()
+    game.frametime_plotter.show()

--- a/arcade/particle.py
+++ b/arcade/particle.py
@@ -1,0 +1,127 @@
+"""
+Particle - Object produced by an Emitter.  Often used in large quantity to produce visual effects effects
+"""
+
+from arcade.sprite import Sprite
+from arcade.draw_commands import Texture
+import arcade.utils
+from pymunk import Vec2d
+
+
+class Particle(Sprite):
+    """Sprite that is emitted from an Emitter"""
+    def __init__(
+        self,
+        filename_or_texture: str,
+        vel: Vec2d,
+        pos: Vec2d = None,
+        angle: float = 0,
+        change_angle: float = 0,
+        scale: float = 1.0,
+        alpha: int = 255,
+        mutation_callback = None
+    ):
+        if pos is None:
+            pos = Vec2d.zero()
+
+        if isinstance(filename_or_texture, Texture):
+            super().__init__(None, scale=scale)
+            self.append_texture(filename_or_texture)
+            self.set_texture(0)
+        else:
+            super().__init__(filename_or_texture, scale=scale)
+
+        self.center_x = pos.x
+        self.center_y = pos.y
+        self.change_x = vel.x
+        self.change_y = vel.y
+        self.angle = angle
+        self.change_angle = change_angle
+        self.alpha = alpha
+        self.mutation_callback = mutation_callback
+
+    def update(self):
+        """Advance the Particle's simulation"""
+        super().update()
+        if self.mutation_callback:
+            self.mutation_callback(self)
+
+    # def draw(self):
+    #     raise NotImplementedError("Particle.draw needs to be implemented")
+
+    def can_reap(self):
+        """Determine if Particle can be deleted"""
+        raise NotImplementedError("Particle.can_reap needs to be implemented")
+
+
+class EternalParticle(Particle):
+    """Particle that has no end to its life"""
+    def __init__(
+        self,
+        filename_or_texture: str,
+        vel: Vec2d,
+        pos: Vec2d = None,
+        angle: float = 0,
+        change_angle: float = 0,
+        scale: float = 1.0,
+        alpha: int = 255,
+        mutation_callback=None
+    ):
+        super().__init__(filename_or_texture, vel, pos, angle, change_angle, scale, alpha, mutation_callback)
+
+    def can_reap(self):
+        """Determine if Particle can be deleted"""
+        return False
+
+
+class LifetimeParticle(Particle):
+    """Particle that lives for a given amount of time and is then deleted"""
+    def __init__(
+        self,
+        filename_or_texture: str,
+        vel: Vec2d,
+        lifetime: float,
+        pos: Vec2d = None,
+        angle: float = 0,
+        change_angle: float = 0,
+        scale: float = 1.0,
+        alpha: int = 255,
+        mutation_callback = None
+    ):
+        super().__init__(filename_or_texture, vel, pos, angle, change_angle, scale, alpha, mutation_callback)
+        self.lifetime_original = lifetime
+        self.lifetime_elapsed = 0.0
+
+    def update(self):
+        """Advance the Particle's simulation"""
+        super().update()
+        self.lifetime_elapsed += 1/60
+
+    def can_reap(self):
+        """Determine if Particle can be deleted"""
+        return self.lifetime_elapsed >= self.lifetime_original
+
+
+class FadeParticle(LifetimeParticle):
+    """Particle that animates its alpha between two values during its lifetime"""
+    def __init__(
+        self,
+        filename_or_texture: str,
+        vel: Vec2d,
+        lifetime: float,
+        pos: Vec2d = None,
+        angle: float = 0,
+        change_angle: float = 0,
+        scale: float = 1.0,
+        start_alpha: int = 255,
+        end_alpha: int = 0,
+        mutation_callback=None
+    ):
+        super().__init__(filename_or_texture, vel, lifetime, pos, angle, change_angle, scale, start_alpha, mutation_callback)
+        self.start_alpha = start_alpha
+        self.end_alpha = end_alpha
+
+    def update(self):
+        """Advance the Particle's simulation"""
+        super().update()
+        self.alpha = arcade.utils.lerp(self.start_alpha, self.end_alpha, self.lifetime_elapsed / self.lifetime_original)

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -1,0 +1,67 @@
+import math
+import random
+from pymunk import Vec2d
+
+def lerp(v1: float, v2: float, u: float) -> float:
+    """linearly interpolate between two values"""
+    return v1 + ((v2 - v1) * u)
+
+def vec_lerp(v1: Vec2d, v2: Vec2d, u: float) -> Vec2d:
+    return Vec2d(
+        lerp(v1.x, v2.x, u),
+        lerp(v1.y, v2.y, u)
+    )
+
+def rand_in_rect(bottom_left: Vec2d, width: float, height: float) -> Vec2d:
+    return Vec2d(
+        random.uniform(bottom_left.x, bottom_left.x + width),
+        random.uniform(bottom_left.y, bottom_left.y + height)
+    )
+
+def rand_in_circle(center: Vec2d, radius: float) -> Vec2d:
+    """Generate a point in a circle, or can think of it as a vector pointing a random direction with a random magnitude <= radius
+    Reference: http://stackoverflow.com/a/30564123
+    Note: This algorithm returns a higher concentration of points around the center of the circle"""
+    # random angle
+    angle = 2 * math.pi * random.random()
+    # random radius
+    r = radius * random.random()
+    # calculating coordinates
+    return Vec2d(
+        r * math.cos(angle) + center.x,
+        r * math.sin(angle) + center.y
+    )
+
+def rand_on_circle(center: Vec2d, radius: float) -> Vec2d:
+    """Note: by passing a random value in for float, you can achieve what rand_in_circle() does"""
+    angle = 2 * math.pi * random.random()
+    return Vec2d(
+        radius * math.cos(angle) + center.x,
+        radius * math.sin(angle) + center.y
+    )
+
+def rand_on_line(pos1: Vec2d, pos2: Vec2d) -> Vec2d:
+    u = random.uniform(0.0, 1.0)
+    return vec_lerp(pos1, pos2, u)
+
+def rand_angle_360_deg():
+    return random.uniform(0.0, 360.0)
+
+def rand_angle_spread_deg(angle: float, half_angle_spread: float) -> float:
+    s = random.uniform(-half_angle_spread, half_angle_spread)
+    return angle + s
+
+def rand_vec_spread_deg(angle: float, half_angle_spread: float, length: float) -> Vec2d:
+    a = rand_angle_spread_deg(angle, half_angle_spread)
+    v = Vec2d().ones()
+    v.length = length
+    v.angle_degrees = a
+    return v
+
+def rand_vec_magnitude(angle: float, lo_magnitude: float, hi_magnitude: float) -> Vec2d:
+    mag = random.uniform(lo_magnitude, hi_magnitude)
+    v = Vec2d().ones()
+    v.length = mag
+    v.angle_degrees = angle
+    return v
+


### PR DESCRIPTION
As I was watching @pvcraven 's Arcade talk from PyCon 2018, I noticed that [particles where mentioned in the "What's Next" portion of the talk](https://www.youtube.com/watch?v=DAWHMHMPVHU&t=24m2s).  I thought I'd take a stab at an initial implementation of particle systems to get things rolling.  
 
I focused on providing the user flexibility (the "what will the particle systems be able to do") and very little effort on the underlying implementation details (the "how") at this point (simply using `Sprite` and `SpriteList`).

I have something functional, so, I'd love it if the community could grab this PR, run [`examples/particle_systems.py`](https://github.com/pvcraven/arcade/blob/1874f5554b1ca774d544d7e9565deadc35fbc3ae/arcade/examples/particle_systems.py) and [`examples/particle_fireworks.py`](https://github.com/pvcraven/arcade/blob/1874f5554b1ca774d544d7e9565deadc35fbc3ae/arcade/examples/particle_fireworks.py) from the examples/ directory to get a sense of what it can do and post feedback here on the PR or on the Issue: #333.

Now, for the TL;DR...

## Goals:
- Declarative syntax - Users are able to assemble relatively complex `Emitter`s with somewhat declarative-ish looking code (see [`examples/particle_systems.py`](https://github.com/pvcraven/arcade/blob/1874f5554b1ca774d544d7e9565deadc35fbc3ae/arcade/examples/particle_systems.py))
- Flexible
  - When creating an `Emitter`, it is passed a callback (see `Emitter.particle_factory`) that allows a user to define the initial state of the `Particle`s that will be emitted.  This allows for a lot of flexibility in controlling a `Particle`.  A number of utility functions were created to make assembling this `particle_factory` callback easier (see `utils.py`).
  - Initial implementation allows any image file on disk or `Texture` object to be used as a particle
- Extensible - User can easily add new behavior to their particle systems by simply writing arbitrary functions and calling them to the `particle_factory` callback function. Can also subclass the existing `Particle` and `EmitController` classes for more flexibility and reuse. 
- Minimal - Tried to create foundational features while keeping implementation small and simple, avoiding the temptation to try to do everything at the outset. Also tried to keep the impact to the existing arcade library code minimal. 

## Implementation Details
- Current implementation is based on `Sprite` and `SpriteList`.  May be a bit heavyweight when compared with traditional particle systems, but it allowed me to get something functional quickly.
- Two client API's
  - A flexible core API - Constructing an `Emitter` requires that the user understand a couple intermediate Python language features such as callbacks and lambdas, but is rewarded with a lot of flexibility.
  - A simplified API for beginners that allows them to create `Emitter` objects with a simple function call.  These functions give up some flexibility found in the core API to make the interface much simpler (see `emitter_simple.py`).
- Plenty of working examples:
    - [`examples/particle_systems.py`](https://github.com/pvcraven/arcade/blob/1874f5554b1ca774d544d7e9565deadc35fbc3ae/arcade/examples/particle_systems.py) - semi-systematically walks through many of the features available
    - [`examples/particle_fireworks.py`](https://github.com/pvcraven/arcade/blob/1874f5554b1ca774d544d7e9565deadc35fbc3ae/arcade/examples/particle_fireworks.py) - example that shows more "real-world" effects
- Can maintain 60 fps performance from one emitter that instantaneously emits 500 particles on a Windows 7 laptop with i7 CPU and integrated graphics card.  The current performance bottleneck is creating and deleting multiple `Sprite`s, not the animating of large numbers of  `Sprite`s.  I have some simple optimizations that help with this (in a forthcoming PR).
- Used pymunk's `Vec2d` for points and velocity vectors in function signatures
- `FrametimePlotter` - Simple utility class that plots the length of each frame using matplotlib and dumps out basic stats (min, max, avg). Useful for identifying spikes in the length of each frame. 

## Possible next steps:
- Optimization - Creating and reaping `Sprite`s causes a spike in the length of a frame, meaning the user sees slight visual hitches when spawning or reaping large numbers of particles at the same time.  (Some initial optimizations will be in another PR). 
- Forces - Provide better support for common "forces" (gravity, wind, drag, turbulence, attract, repel, etc.).  The `Emitter` does currently support hand-built forces (see the use of `Emitter.mutation_callback` in [`examples/particle_fireworks.py`](https://github.com/pvcraven/arcade/blob/1874f5554b1ca774d544d7e9565deadc35fbc3ae/arcade/examples/particle_fireworks.py)) but some work can be done to make this easier on the user.
- Collision - have particle respond (ex: disappear, bounce) when they collide with other things.
- Refactor - `Particle`s currently must be `Sprite`s. Rework the particle system API and possibly some other arcade classes so that other objects (ex: pixels, polygons, `Shape`, `ShapeElementList`?) can be used as `Particle`s.
- `Emitter`s must be drawn and updated, just like `Sprite`s, so it usually makes sense to put them in a list (see `self.emitters` in [`examples/particle_fireworks.py`](https://github.com/pvcraven/arcade/blob/1874f5554b1ca774d544d7e9565deadc35fbc3ae/arcade/examples/particle_fireworks.py)). But, then the functionality here starts to look and feel somewhat like parts of `SpriteList`.  There may be an opportunity to extract the "enables lists of things to be updated and drawn" logic from `SpriteList`  and be able to use it in a more generic fashion (with Sprites, Emitters, Particles, even `Shape`s?) .  More ideas on this later.

## Known issues:
- can't animate a `Sprite`'s scale when it has a dynamically generated texture (probably bug #331)