### PR TITLE
Remove dependency on pymunk and matplotlib #343

### DIFF
--- a/arcade/__init__.py
+++ b/arcade/__init__.py
@@ -35,4 +35,3 @@ from arcade.isometric import *
 from arcade.text import draw_text
 from arcade.text import create_text
 from arcade.text import render_text
-from arcade.examples.frametime_plotter import *

--- a/arcade/arcade_types.py
+++ b/arcade/arcade_types.py
@@ -9,4 +9,5 @@ RGB = Union[Tuple[int, int, int], List[int]]
 RGBA = Union[Tuple[int, int, int, int], List[int]]
 Color = Union[RGB, RGBA]
 Point = Union[Tuple[float, float], List[float]]
+Vector = Point
 PointList = Union[Tuple[Point, ...], List[Point]]

--- a/arcade/emitter_simple.py
+++ b/arcade/emitter_simple.py
@@ -7,11 +7,12 @@ These trade away some flexibility in favor of simplicity to allow beginners to s
 import arcade
 import random
 from typing import List
-from pymunk import Vec2d
+from arcade.arcade_types import Point
+from arcade.particle import FilenameOrTexture
 
 def make_burst_emitter(
-        pos: Vec2d,
-        filenames_and_textures: List[str],  # Also supports Texture objects in the List
+        center_xy: Point,
+        filenames_and_textures: List[FilenameOrTexture],
         particle_count: int,
         particle_speed: float,
         particle_lifetime_min: float,
@@ -24,19 +25,19 @@ def make_burst_emitter(
     if fade_particles:
         particle_factory = arcade.FadeParticle
     return arcade.Emitter(
-        pos=pos,
+        center_xy=center_xy,
         emit_controller=arcade.EmitBurst(particle_count),
         particle_factory=lambda emitter: particle_factory(
             filename_or_texture=random.choice(filenames_and_textures),
-            vel=arcade.rand_in_circle(Vec2d.zero(), particle_speed),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), particle_speed),
             lifetime=random.uniform(particle_lifetime_min, particle_lifetime_max),
             scale=particle_scale
         )
     )
 
 def make_interval_emitter(
-        pos: Vec2d,
-        filenames_and_textures: List[str], # Also supports Texture objects in the List
+        center_xy: Point,
+        filenames_and_textures: List[FilenameOrTexture],
         emit_interval: float,
         emit_duration: float,
         particle_speed: float,
@@ -50,11 +51,11 @@ def make_interval_emitter(
     if fade_particles:
         particle_factory = arcade.FadeParticle
     return arcade.Emitter(
-        pos=pos,
+        center_xy=center_xy,
         emit_controller=arcade.EmitterIntervalWithTime(emit_interval, emit_duration),
         particle_factory=lambda emitter: particle_factory(
             filename_or_texture=random.choice(filenames_and_textures),
-            vel=arcade.rand_on_circle(Vec2d.zero(), particle_speed),
+            change_xy=arcade.rand_on_circle((0.0, 0.0), particle_speed),
             lifetime=random.uniform(particle_lifetime_min, particle_lifetime_max),
             scale=particle_scale
         )

--- a/arcade/examples/particle_stress.py
+++ b/arcade/examples/particle_stress.py
@@ -8,21 +8,21 @@ python -m arcade.examples.sprite_list_particle_fireworks
 """
 import os
 import arcade
-from pymunk import Vec2d
+from arcade.examples.frametime_plotter import FrametimePlotter
 
 SCREEN_WIDTH = 800
 SCREEN_HEIGHT = 600
 SCREEN_TITLE = "Particle stress test"
 TEXTURE = "images/pool_cue_ball.png"
 
+
 def make_emitter():
     return arcade.Emitter(
-        pos=Vec2d(SCREEN_WIDTH/2, SCREEN_HEIGHT/2),
-        # pos=Vec2d.zero(),
+        center_xy=(SCREEN_WIDTH/2, SCREEN_HEIGHT/2),
         emit_controller=arcade.EmitterIntervalWithTime(0.0004, 15.0),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), 5.0),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), 5.0),
             lifetime=1.0,
             scale=0.5,
             alpha=128
@@ -42,7 +42,7 @@ class MyGame(arcade.Window):
 
         self.emitter = make_emitter()
         arcade.set_background_color(arcade.color.BLACK)
-        self.frametime_plotter = arcade.FrametimePlotter()
+        self.frametime_plotter = FrametimePlotter()
 
     def update(self, delta_time):
         self.emitter.update()

--- a/arcade/examples/particle_systems.py
+++ b/arcade/examples/particle_systems.py
@@ -11,8 +11,8 @@ If Python and Arcade are installed, this example can be run from the command lin
 python -m arcade.examples.sprite_list_particle_systems
 """
 import arcade
+from arcade.examples.frametime_plotter import FrametimePlotter
 import pyglet
-from pymunk import Vec2d
 import os
 import random
 import math
@@ -22,7 +22,7 @@ SCREEN_HEIGHT = 600
 SCREEN_TITLE = "Particle System Examples"
 QUIET_BETWEEN_SPAWNS = 0.25 # time between spawning another particle system
 EMITTER_TIMEOUT = 10*60
-CENTER_POS = Vec2d(SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2)
+CENTER_POS = (SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2)
 BURST_PARTICLE_COUNT = 500
 TEXTURE = "images/pool_cue_ball.png"
 TEXTURE2 = "images/playerShip3_orange.png"
@@ -51,11 +51,11 @@ def sine_wave(t, min_x, max_x, wavelength):
 def emitter_0():
     """Burst, emit from center, particle with lifetime"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -66,11 +66,11 @@ def emitter_0():
 def emitter_1():
     """Burst, emit from center, particle lifetime 1.0 seconds"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=1.0,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -81,11 +81,11 @@ def emitter_1():
 def emitter_2():
     """Burst, emit from center, particle lifetime random in range"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(),PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0),PARTICLE_SPEED_FAST),
             lifetime=random.uniform(DEFAULT_PARTICLE_LIFETIME - 1.0, DEFAULT_PARTICLE_LIFETIME),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -96,13 +96,13 @@ def emitter_2():
 def emitter_3():
     """Burst, emit in circle"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_SLOW),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
-            pos=arcade.rand_in_circle(Vec2d.zero(), 100),
+            center_xy=arcade.rand_in_circle((0.0, 0.0), 100),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
         )
@@ -112,13 +112,13 @@ def emitter_3():
 def emitter_4():
     """Burst, emit on circle"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_SLOW),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
-            pos=arcade.rand_on_circle(Vec2d.zero(), 100),
+            center_xy=arcade.rand_on_circle((0.0, 0.0), 100),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
         )
@@ -128,15 +128,15 @@ def emitter_4():
 def emitter_5():
     """Burst, emit in rectangle"""
     width, height = 200, 100
-    centering_offset = Vec2d(-width/2, -height/2)
+    centering_offset = (-width/2, -height/2)
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_SLOW),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
-            pos=arcade.rand_in_rect(centering_offset, width, height),
+            center_xy=arcade.rand_in_rect(centering_offset, width, height),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
         )
@@ -146,13 +146,13 @@ def emitter_5():
 def emitter_6():
     """Burst, emit on line"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_SLOW),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
-            pos=arcade.rand_on_line(Vec2d.zero(), Vec2d(SCREEN_WIDTH, SCREEN_HEIGHT)),
+            center_xy=arcade.rand_on_line((0.0, 0.0), (SCREEN_WIDTH, SCREEN_HEIGHT)),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
         )
@@ -162,11 +162,11 @@ def emitter_6():
 def emitter_7():
     """Burst, emit from center, velocity fixed speed around 360 degrees"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT // 4),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_on_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_on_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -177,13 +177,12 @@ def emitter_7():
 def emitter_8():
     """Burst, emit from center, velocity in rectangle"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_rect(Vec2d(-2.0, -2.0), 4.0, 4.0),
+            change_xy=arcade.rand_in_rect((-2.0, -2.0), 4.0, 4.0),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
-            pos=Vec2d.zero(),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
         )
@@ -193,11 +192,11 @@ def emitter_8():
 def emitter_9():
     """Burst, emit from center, velocity in fixed angle and random speed"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT // 4),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_vec_magnitude(45, 1.0, 4.0),
+            change_xy=arcade.rand_vec_magnitude(45, 1.0, 4.0),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -208,11 +207,11 @@ def emitter_9():
 def emitter_10():
     """Burst, emit from center, velocity from angle with spread"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT // 4),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_vec_spread_deg(90, 45, 2.0),
+            change_xy=arcade.rand_vec_spread_deg(90, 45, 2.0),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -223,11 +222,11 @@ def emitter_10():
 def emitter_11():
     """Burst, emit from center, velocity along a line"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT // 4),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_on_line(Vec2d(-2, 1), Vec2d(2, 1)),
+            change_xy=arcade.rand_on_line((-2, 1), (2, 1)),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -238,11 +237,11 @@ def emitter_11():
 def emitter_12():
     """Infinite emitting w/ eternal particle"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitInterval(0.02),
         particle_factory=lambda emitter: arcade.EternalParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
         )
@@ -252,11 +251,11 @@ def emitter_12():
 def emitter_13():
     """Interval, emit particle every 0.01 seconds for one second"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -267,11 +266,11 @@ def emitter_13():
 def emitter_14():
     """Interval, emit from center, particle lifetime 1.0 seconds"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=1.0,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -282,11 +281,11 @@ def emitter_14():
 def emitter_15():
     """Interval, emit from center, particle lifetime random in range"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=random.uniform( DEFAULT_PARTICLE_LIFETIME - 1.0, DEFAULT_PARTICLE_LIFETIME),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -297,13 +296,13 @@ def emitter_15():
 def emitter_16():
     """Interval, emit in circle"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_SLOW),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
-            pos=arcade.rand_in_circle(Vec2d.zero(), 100),
+            center_xy=arcade.rand_in_circle((0.0, 0.0), 100),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
         )
@@ -313,13 +312,13 @@ def emitter_16():
 def emitter_17():
     """Interval, emit on circle"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_SLOW),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
-            pos=arcade.rand_on_circle(Vec2d.zero(), 100),
+            center_xy=arcade.rand_on_circle((0.0, 0.0), 100),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
         )
@@ -329,15 +328,15 @@ def emitter_17():
 def emitter_18():
     """Interval, emit in rectangle"""
     width, height = 200, 100
-    centering_offset = Vec2d(-width/2, -height/2)
+    centering_offset = (-width/2, -height/2)
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_SLOW),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
-            pos=arcade.rand_in_rect(centering_offset, width, height),
+            center_xy=arcade.rand_in_rect(centering_offset, width, height),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
         )
@@ -351,13 +350,13 @@ def emitter_18():
 def emitter_19():
     """Interval, emit on line"""
     e = arcade.Emitter(
-        pos=Vec2d.zero(),
+        center_xy=(0.0, 0.0),
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_SLOW),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_SLOW),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
-            pos=arcade.rand_on_line(Vec2d.zero(), Vec2d(SCREEN_WIDTH, SCREEN_HEIGHT)),
+            center_xy=arcade.rand_on_line((0.0, 0.0), (SCREEN_WIDTH, SCREEN_HEIGHT)),
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
         )
@@ -367,11 +366,11 @@ def emitter_19():
 def emitter_20():
     """Interval, emit from center, velocity fixed speed around 360 degrees"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_on_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_on_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -382,11 +381,11 @@ def emitter_20():
 def emitter_21():
     """Interval, emit from center, velocity in rectangle"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_rect(Vec2d(-2.0, -2.0), 4.0, 4.0),
+            change_xy=arcade.rand_in_rect((-2.0, -2.0), 4.0, 4.0),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -397,11 +396,11 @@ def emitter_21():
 def emitter_22():
     """Interval, emit from center, velocity in fixed angle and speed"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(0.2, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=Vec2d(1.0, 1.0),
+            change_xy=(1.0, 1.0),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=128
@@ -412,11 +411,11 @@ def emitter_22():
 def emitter_23():
     """Interval, emit from center, velocity in fixed angle and random speed"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 8, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_vec_magnitude(45, 1.0, 4.0),
+            change_xy=arcade.rand_vec_magnitude(45, 1.0, 4.0),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -427,11 +426,11 @@ def emitter_23():
 def emitter_24():
     """Interval, emit from center, velocity from angle with spread"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_vec_spread_deg(90, 45, 2.0),
+            change_xy=arcade.rand_vec_spread_deg(90, 45, 2.0),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -442,11 +441,11 @@ def emitter_24():
 def emitter_25():
     """Interval, emit from center, velocity along a line"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_on_line(Vec2d(-2, 1), Vec2d(2, 1)),
+            change_xy=arcade.rand_on_line((-2, 1), (2, 1)),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=DEFAULT_ALPHA
@@ -457,11 +456,11 @@ def emitter_25():
 def emitter_26():
     """Interval, emit particles every 0.4 seconds and stop after emitting 5"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithCount(0.4, 5),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=0.6,
             alpha=128
@@ -472,11 +471,11 @@ def emitter_26():
 def emitter_27():
     """Maintain a steady count of particles"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitMaintainCount(3),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_on_circle(Vec2d.zero(), 2.0),
+            change_xy=arcade.rand_on_circle((0.0, 0.0), 2.0),
             lifetime=random.uniform(1.0, 3.0),
         )
     )
@@ -485,11 +484,11 @@ def emitter_27():
 def emitter_28():
     """random particle textures"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 5, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=random.choice((TEXTURE, TEXTURE2, TEXTURE3)),
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE
         )
@@ -499,11 +498,11 @@ def emitter_28():
 def emitter_29():
     """random particle scale"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 5, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=random.uniform(0.1, 0.8),
             alpha=DEFAULT_ALPHA
@@ -514,11 +513,11 @@ def emitter_29():
 def emitter_30():
     """random particle alpha"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 5, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE,
             alpha=random.uniform(32, 128)
@@ -529,11 +528,11 @@ def emitter_30():
 def emitter_31():
     """Constant particle angle"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 5, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE2,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             angle=45,
             scale=DEFAULT_SCALE
@@ -544,11 +543,11 @@ def emitter_31():
 def emitter_32():
     """animate particle angle"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL * 5, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE2,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             change_angle=2,
             scale=DEFAULT_SCALE
@@ -559,11 +558,11 @@ def emitter_32():
 def emitter_33():
     """Particles that fade over time"""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.FadeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE
         )
@@ -574,11 +573,11 @@ def emitter_34():
     """Dynamically generated textures, burst emitting, fading particles"""
     textures = [arcade.make_soft_circle_texture(48, p) for p in (arcade.color.GREEN, arcade.color.BLUE_GREEN)]
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitBurst(BURST_PARTICLE_COUNT),
         particle_factory=lambda emitter: arcade.FadeParticle(
             filename_or_texture=random.choice(textures),
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST),
             lifetime=DEFAULT_PARTICLE_LIFETIME,
             scale=DEFAULT_SCALE
         )
@@ -590,11 +589,11 @@ def emitter_35():
     soft_circle = arcade.make_soft_circle_texture(80, (255, 64, 64))
     textures = (TEXTURE, TEXTURE2, TEXTURE3, TEXTURE4, TEXTURE5, TEXTURE6, TEXTURE7, soft_circle)
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(0.01, 1.0),
         particle_factory=lambda emitter: arcade.FadeParticle(
             filename_or_texture=random.choice(textures),
-            vel=arcade.rand_in_circle(Vec2d.zero(), PARTICLE_SPEED_FAST * 2),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), PARTICLE_SPEED_FAST * 2),
             lifetime=random.uniform(1.0, 3.5),
             angle=random.uniform(0, 360),
             change_angle=random.uniform(-3, 3),
@@ -617,11 +616,11 @@ def emitter_36():
             self.center_y = sine_wave(self.elapsed, 0, SCREEN_HEIGHT, SCREEN_HEIGHT / 100)
 
     e = MovingEmitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitInterval(0.005),
         particle_factory=lambda emitter: arcade.FadeParticle(
             filename_or_texture=TEXTURE,
-            vel=arcade.rand_in_circle(Vec2d.zero(), 0.1),
+            change_xy=arcade.rand_in_circle((0.0, 0.0), 0.1),
             lifetime=random.uniform(1.5, 5.5),
             scale=random.uniform(0.05, 0.2)
         )
@@ -631,11 +630,11 @@ def emitter_36():
 def emitter_37():
     """Rotating emitter. Particles initial velocity is relative to emitter's angle."""
     e = arcade.Emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         emit_controller=arcade.EmitterIntervalWithTime(DEFAULT_EMIT_INTERVAL, DEFAULT_EMIT_DURATION),
         particle_factory=lambda emitter: arcade.LifetimeParticle(
             filename_or_texture=TEXTURE,
-            vel=Vec2d(0.0, 2.0),
+            change_xy=(0.0, 2.0),
             lifetime=2.0,
             scale=DEFAULT_SCALE
         )
@@ -646,7 +645,7 @@ def emitter_37():
 def emitter_38():
     """Use simple emitter interface to create a burst emitter"""
     e = arcade.make_burst_emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         filenames_and_textures=(TEXTURE, TEXTURE3, TEXTURE4),
         particle_count=50,
         particle_speed=2.5,
@@ -660,7 +659,7 @@ def emitter_38():
 def emitter_39():
     """Use simple emitter interface to create an interval emitter"""
     e = arcade.make_interval_emitter(
-        pos=CENTER_POS,
+        center_xy=CENTER_POS,
         filenames_and_textures=(TEXTURE, TEXTURE3, TEXTURE4),
         emit_interval=0.01,
         emit_duration=2.0,
@@ -694,7 +693,7 @@ class MyGame(arcade.Window):
         self.emitter = None
         self.obj = arcade.Sprite("images/bumper.png", 0.2, center_x=0, center_y=15)
         self.obj.change_x = 3
-        self.frametime_plotter = arcade.FrametimePlotter()
+        self.frametime_plotter = FrametimePlotter()
         pyglet.clock.schedule_once(self.next_emitter, QUIET_BETWEEN_SPAWNS)
 
     def next_emitter(self, time_delta):

--- a/arcade/particle.py
+++ b/arcade/particle.py
@@ -5,25 +5,24 @@ Particle - Object produced by an Emitter.  Often used in large quantity to produ
 from arcade.sprite import Sprite
 from arcade.draw_commands import Texture
 import arcade.utils
-from pymunk import Vec2d
+from arcade.arcade_types import Point, Vector
+from typing import Union
 
+FilenameOrTexture = Union[str, Texture]
 
 class Particle(Sprite):
     """Sprite that is emitted from an Emitter"""
     def __init__(
         self,
-        filename_or_texture: str,
-        vel: Vec2d,
-        pos: Vec2d = None,
+        filename_or_texture: FilenameOrTexture,
+        change_xy: Vector,
+        center_xy: Point = (0.0, 0.0),
         angle: float = 0,
         change_angle: float = 0,
         scale: float = 1.0,
         alpha: int = 255,
         mutation_callback = None
     ):
-        if pos is None:
-            pos = Vec2d.zero()
-
         if isinstance(filename_or_texture, Texture):
             super().__init__(None, scale=scale)
             self.append_texture(filename_or_texture)
@@ -31,10 +30,10 @@ class Particle(Sprite):
         else:
             super().__init__(filename_or_texture, scale=scale)
 
-        self.center_x = pos.x
-        self.center_y = pos.y
-        self.change_x = vel.x
-        self.change_y = vel.y
+        self.center_x = center_xy[0]
+        self.center_y = center_xy[1]
+        self.change_x = change_xy[0]
+        self.change_y = change_xy[1]
         self.angle = angle
         self.change_angle = change_angle
         self.alpha = alpha
@@ -58,16 +57,16 @@ class EternalParticle(Particle):
     """Particle that has no end to its life"""
     def __init__(
         self,
-        filename_or_texture: str,
-        vel: Vec2d,
-        pos: Vec2d = None,
+        filename_or_texture: FilenameOrTexture,
+        change_xy: Vector,
+        center_xy: Point = (0.0, 0.0),
         angle: float = 0,
         change_angle: float = 0,
         scale: float = 1.0,
         alpha: int = 255,
         mutation_callback=None
     ):
-        super().__init__(filename_or_texture, vel, pos, angle, change_angle, scale, alpha, mutation_callback)
+        super().__init__(filename_or_texture, change_xy, center_xy, angle, change_angle, scale, alpha, mutation_callback)
 
     def can_reap(self):
         """Determine if Particle can be deleted"""
@@ -78,17 +77,17 @@ class LifetimeParticle(Particle):
     """Particle that lives for a given amount of time and is then deleted"""
     def __init__(
         self,
-        filename_or_texture: str,
-        vel: Vec2d,
+        filename_or_texture: FilenameOrTexture,
+        change_xy: Vector,
         lifetime: float,
-        pos: Vec2d = None,
+        center_xy: Point = (0.0, 0.0),
         angle: float = 0,
         change_angle: float = 0,
         scale: float = 1.0,
         alpha: int = 255,
         mutation_callback = None
     ):
-        super().__init__(filename_or_texture, vel, pos, angle, change_angle, scale, alpha, mutation_callback)
+        super().__init__(filename_or_texture, change_xy, center_xy, angle, change_angle, scale, alpha, mutation_callback)
         self.lifetime_original = lifetime
         self.lifetime_elapsed = 0.0
 
@@ -106,10 +105,10 @@ class FadeParticle(LifetimeParticle):
     """Particle that animates its alpha between two values during its lifetime"""
     def __init__(
         self,
-        filename_or_texture: str,
-        vel: Vec2d,
+        filename_or_texture: FilenameOrTexture,
+        change_xy: Vector,
         lifetime: float,
-        pos: Vec2d = None,
+        center_xy: Point = (0.0, 0.0),
         angle: float = 0,
         change_angle: float = 0,
         scale: float = 1.0,
@@ -117,7 +116,7 @@ class FadeParticle(LifetimeParticle):
         end_alpha: int = 0,
         mutation_callback=None
     ):
-        super().__init__(filename_or_texture, vel, lifetime, pos, angle, change_angle, scale, start_alpha, mutation_callback)
+        super().__init__(filename_or_texture, change_xy, lifetime, center_xy, angle, change_angle, scale, start_alpha, mutation_callback)
         self.start_alpha = start_alpha
         self.end_alpha = end_alpha
 

--- a/arcade/utils.py
+++ b/arcade/utils.py
@@ -1,24 +1,25 @@
 import math
 import random
-from pymunk import Vec2d
+from arcade.arcade_types import Point, Vector
+
 
 def lerp(v1: float, v2: float, u: float) -> float:
     """linearly interpolate between two values"""
     return v1 + ((v2 - v1) * u)
 
-def vec_lerp(v1: Vec2d, v2: Vec2d, u: float) -> Vec2d:
-    return Vec2d(
-        lerp(v1.x, v2.x, u),
-        lerp(v1.y, v2.y, u)
+def lerp_vec(v1: Vector, v2: Vector, u: float) -> Vector:
+    return (
+        lerp(v1[0], v2[0], u),
+        lerp(v1[1], v2[1], u)
     )
 
-def rand_in_rect(bottom_left: Vec2d, width: float, height: float) -> Vec2d:
-    return Vec2d(
-        random.uniform(bottom_left.x, bottom_left.x + width),
-        random.uniform(bottom_left.y, bottom_left.y + height)
+def rand_in_rect(bottom_left: Point, width: float, height: float) -> Point:
+    return (
+        random.uniform(bottom_left[0], bottom_left[0] + width),
+        random.uniform(bottom_left[1], bottom_left[1] + height)
     )
 
-def rand_in_circle(center: Vec2d, radius: float) -> Vec2d:
+def rand_in_circle(center: Point, radius: float):
     """Generate a point in a circle, or can think of it as a vector pointing a random direction with a random magnitude <= radius
     Reference: http://stackoverflow.com/a/30564123
     Note: This algorithm returns a higher concentration of points around the center of the circle"""
@@ -27,22 +28,22 @@ def rand_in_circle(center: Vec2d, radius: float) -> Vec2d:
     # random radius
     r = radius * random.random()
     # calculating coordinates
-    return Vec2d(
-        r * math.cos(angle) + center.x,
-        r * math.sin(angle) + center.y
+    return (
+        r * math.cos(angle) + center[0],
+        r * math.sin(angle) + center[1]
     )
 
-def rand_on_circle(center: Vec2d, radius: float) -> Vec2d:
+def rand_on_circle(center: Point, radius: float) -> Point:
     """Note: by passing a random value in for float, you can achieve what rand_in_circle() does"""
     angle = 2 * math.pi * random.random()
-    return Vec2d(
-        radius * math.cos(angle) + center.x,
-        radius * math.sin(angle) + center.y
+    return (
+        radius * math.cos(angle) + center[0],
+        radius * math.sin(angle) + center[1]
     )
 
-def rand_on_line(pos1: Vec2d, pos2: Vec2d) -> Vec2d:
+def rand_on_line(pos1: Point, pos2: Point) -> Point:
     u = random.uniform(0.0, 1.0)
-    return vec_lerp(pos1, pos2, u)
+    return lerp_vec(pos1, pos2, u)
 
 def rand_angle_360_deg():
     return random.uniform(0.0, 360.0)
@@ -51,17 +52,72 @@ def rand_angle_spread_deg(angle: float, half_angle_spread: float) -> float:
     s = random.uniform(-half_angle_spread, half_angle_spread)
     return angle + s
 
-def rand_vec_spread_deg(angle: float, half_angle_spread: float, length: float) -> Vec2d:
+def rand_vec_spread_deg(angle: float, half_angle_spread: float, length: float) -> Vector:
     a = rand_angle_spread_deg(angle, half_angle_spread)
-    v = Vec2d().ones()
-    v.length = length
-    v.angle_degrees = a
-    return v
+    vel = _Vec2.from_polar(a, length)
+    return vel.as_tuple()
 
-def rand_vec_magnitude(angle: float, lo_magnitude: float, hi_magnitude: float) -> Vec2d:
+def rand_vec_magnitude(angle: float, lo_magnitude: float, hi_magnitude: float) -> Vector:
     mag = random.uniform(lo_magnitude, hi_magnitude)
-    v = Vec2d().ones()
-    v.length = mag
-    v.angle_degrees = angle
-    return v
+    vel = _Vec2.from_polar(angle, mag)
+    return vel.as_tuple()
 
+
+class _Vec2:
+    """2D vector used to do operate points and vectors
+
+    Note: intended to be used for internal implementations only. Should not be part of public interfaces (ex: function parameters or return values)."""
+
+    __slots__ = ['x', 'y']
+    def __init__(self, x, y=None):
+        try:
+            # see if first argument is an iterable with two items
+            self.x = x[0]
+            self.y = x[1]
+        except TypeError:
+            self.x = x
+            self.y = y
+
+    @staticmethod
+    def from_polar(angle, radius):
+        rads = math.radians(angle)
+        return _Vec2(radius * math.cos(rads), radius * math.sin(rads))
+
+    def __add__(self, other):
+        return _Vec2(self.x + other.x, self.y + other.y)
+
+    def __sub__(self, other):
+        return _Vec2(self.x - other.x, self.y - other.y)
+
+    def __mul__(self, other):
+        return _Vec2(self.x * other.x, self.y * other.y)
+
+    def __truediv__(self, other):
+        return _Vec2(self.x / other.x, self.y / other.y)
+
+    def __iter__(self):
+        yield self.x
+        yield self.y
+
+    def length(self):
+        """return the length (magnitude) of the vector"""
+        return math.sqrt(self.x**2 + self.y**2)
+
+    def dot(self, other):
+        return self.x * other.x + self.y * other.y
+
+    def __repr__(self):
+        return f"Vec2({self.x},{self.y})"
+
+    def rotated(self, angle):
+        """Returns the new vector resulting when this vector is rotated by the given angle in degrees"""
+        rads = math.radians(angle)
+        cosine = math.cos(rads)
+        sine = math.sin(rads)
+        return _Vec2(
+            (self.x*cosine) - (self.y*sine),
+            (self.y*cosine) + (self.x*sine)
+        )
+
+    def as_tuple(self) -> Point:
+        return self.x, self.y

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,151 @@
+"""
+Unit tests for utils.py
+
+Can run these tests individually with:
+python -m pytest tests/unit/test_utils.py
+"""
+
+import arcade
+from pytest import approx
+from arcade.utils import _Vec2
+
+
+def test_lerp():
+    assert arcade.lerp(2.0, 4.0, 0.75) == approx(3.5)
+
+
+def test_lerp_vec():
+    vec = arcade.lerp_vec((0.0, 2.0), (8.0, 4.0), 0.25)
+    assert vec[0] == approx(2.0)
+    assert vec[1] == approx(2.5)
+    vec = arcade.lerp_vec((0.0, 2.0), (8.0, 4.0), -0.25)
+    assert vec[0] == approx(-2.0)
+    assert vec[1] == approx(1.5)
+
+
+def test_rand_in_rect():
+    """Smoke test"""
+    arcade.rand_in_rect((10.0, 20.0), 30.5, 5.1)
+
+
+def test_rand_in_circle():
+    """Smoke test"""
+    arcade.rand_in_circle((0, 0), 10.0)
+
+
+def test_rand_on_circle():
+    """Smoke test"""
+    arcade.rand_on_circle((10.0, 20.0), 15.5)
+
+
+def test_rand_on_line():
+    """Smoke test"""
+    arcade.rand_on_line((-5.5, -2.2), (5.2, 14.7))
+
+
+def test_rand_angle_360_deg():
+    """Smoke test"""
+    arcade.rand_angle_360_deg()
+
+
+def test_rand_angle_spread_deg():
+    """Smoke test"""
+    arcade.rand_angle_spread_deg(45.0, 5.0)
+
+
+def test_rand_vec_spread_deg():
+    """Smoke test"""
+    arcade.rand_vec_spread_deg(-45.0, 5.0, 3.3)
+
+
+def test_rand_vec_magnitude():
+    """Smoke test"""
+    arcade.rand_vec_magnitude(30.5, 3.3, 4.4)
+
+
+def test_vec():
+    # 2 floats
+    v = _Vec2(3.3, 5.5)
+    assert v.x == 3.3
+    assert v.y == 5.5
+
+    # one tuple
+    v = _Vec2((1.1, 2.2))
+    assert v.x == 1.1
+    assert v.y == 2.2
+
+    # iterator access
+    items = [item for item in v]
+    assert items == [1.1, 2.2]
+
+    # tuple access
+    assert v.as_tuple() == (1.1, 2.2)
+
+    # string representation
+    assert repr(v) == "Vec2(1.1,2.2)"
+    assert str(v) == "Vec2(1.1,2.2)"
+
+
+def test_vec_length():
+    assert _Vec2(5.0, 0.0).length() == approx(5.0)
+    assert _Vec2(0.0, -5.0).length() == approx(5.0)
+    assert _Vec2(3.5355339, 3.5355339).length() == approx(5.0)
+    assert _Vec2(-3.5355339, -3.5355339).length() == approx(5.0)
+
+
+def test_vec_from_polar():
+    v = _Vec2.from_polar(45, 4.0)
+    assert v.x == approx(2.8284271)
+    assert v.y == approx(2.8284271)
+
+
+def test_vec_add_and_subtract():
+    v1 = _Vec2(5.0, 4.0)
+    v2 = _Vec2(-1.5, 3.0)
+
+    v3 = v1 + v2
+    assert v3.x == 3.5
+    assert v3.y == 7.0
+
+    v3 = v1 - v2
+    assert v3.x == 6.5
+    assert v3.y == 1.0
+
+
+def test_vec_mult_and_divide():
+    v1 = _Vec2(5.0, 4.0)
+    v2 = _Vec2(0.5, -0.25)
+
+    v3 = v1 * v2
+    assert v3.x == 2.5
+    assert v3.y == -1.0
+
+    v4 = v3 / v2
+    assert v4.x == v1.x
+    assert v4.y == v1.y
+
+
+def test_vec_dot():
+    v1 = _Vec2(5.0, 4.0)
+    v2 = _Vec2(0.5, -0.25)
+    assert v1.dot(v2) == 1.5
+
+
+def test_vec_rotated():
+    v1 = _Vec2(3.0, 0.0)
+
+    rotated = v1.rotated(0.0)
+    assert rotated.x == approx(3.0)
+    assert rotated.y == approx(0.0)
+
+    rotated = v1.rotated(90.0)
+    assert rotated.x == approx(0.0)
+    assert rotated.y == approx(3.0)
+
+    rotated = v1.rotated(-90.0)
+    assert rotated.x == approx(0.0)
+    assert rotated.y == approx(-3.0)
+
+    rotated = v1.rotated(45.0)
+    assert rotated.x == approx(2.12132)
+    assert rotated.y == approx(2.12132)


### PR DESCRIPTION
- Remove pymunk dependency by replacing pymunk.Vec2d with 2-tuples
    - Use Point (and newly added Vector) type hints to represent 2-tuples
- remove matplotlib dependency (via FrametimePlotter).  FrametimePlotter is only used by files in examples/ now.
- rename "pos" and "vel" parameters in Emitter and Particle class hierarchies to "center_xy" and "change_xy" to indicate that they take 2-tuples and to be more consistent with naming elsewhere in the codebase.    
- added vector class (utils._Vec2) to help with internal implementation details.  This class is not meant to be a part of the public interface (ex: function parameters or return values) 
- updated all Emitter test scripts in examples/
- created some (very light coverage) unit tests for the utils.py file, including the new _Vec2 class.
- confirmed there was no performance degradation using stress_test_draw_moving_arcade.py and particle_stress.py

Regarding the unit tests, I'm not exactly sure how they are suppose to be run (`make test` didn't seem to do anything and a plain `pytest` seemed to have problems).  But, the tests can be run with: `python -m pytest tests/unit/test_utils.py`. 
