### PR TITLE
Removed all comments from pyinstaller batch

### DIFF
--- a/arcade/examples/pyinstaller/build-exe.bat
+++ b/arcade/examples/pyinstaller/build-exe.bat
@@ -1,8 +1,8 @@
-rem @echo off
-for /f %%i in ('python -c "import site; print(site.getsitepackages()[0])"') do set PYTHON_ROOT="%%i"
-rem copy %PYTHON_ROOT%\Lib\site-packages\arcade\Win64\avbin.dll .
-rem copy avbin.dll avbin64.dll
-rem pyinstaller --exclude-module tkinter --add-data resources;resources --add-data ./avbin64.dll;. --add-data ./avbin.dll;Win64 --onefile --noconsole sample.py
-rem del avbin.dll
-rem del avbin64.dll
-rem pause
+@echo off
+/f %%i in ('python -c "import site; print(site.getsitepackages()[0])"') do set PYTHON_ROOT="%%i"
+copy %PYTHON_ROOT%\Lib\site-packages\arcade\Win64\avbin.dll .
+copy avbin.dll avbin64.dll
+pyinstaller --exclude-module tkinter --add-data resources;resources --add-data ./avbin64.dll;. --add-data ./avbin.dll;Win64 --onefile --noconsole sample.py
+del avbin.dll
+del avbin64.dll
+pause


### PR DESCRIPTION
Hi,

Perhaps there's something I'm not understanding here. But having rem in front of all commands in the pyinstaller bat just makes them comments, right? No commands are actually executed, making the example bat kinda useless. This patch just removes the rem from all lines.

If there's a point to this, feel free to ignore this pull request :)