### PR TITLE
Fix error in Sprite.set_position

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -199,7 +199,7 @@ class Sprite:
         """
         Set a sprite's position
         """
-        self._set_position(self, (center_x, center_y))
+        self._set_position((center_x, center_y))
 
     def set_points(self, points: Sequence[Sequence[float]]):
         """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
 import pytest
 
-pytest.main("-x tests/unit2")
+pytest.main(["-x", "tests/unit2"])

--- a/tests/unit2/test_drawing_primitives.py
+++ b/tests/unit2/test_drawing_primitives.py
@@ -19,7 +19,8 @@ class MyGame(arcade.Window):
         # code, but it is needed to easily run the examples using "python -m"
         # as mentioned at the top of this program.
         file_path = os.path.dirname(os.path.abspath(__file__))
-        os.chdir(f"{file_path}\\..\\..\\arcade\\examples")
+        new_path = os.path.join(file_path, '..', '..', 'arcade', 'examples')
+        os.chdir(new_path)
 
         arcade.set_background_color(arcade.color.WHITE)
 

--- a/tests/unit2/test_sprite.py
+++ b/tests/unit2/test_sprite.py
@@ -27,6 +27,7 @@ class MyTestWindow(arcade.Window):
         self.coin_list = arcade.SpriteList()
         sprite = arcade.Sprite("../../arcade/examples/images/coin_01.png", CHARACTER_SCALING)
         sprite.position = (130, 130)
+        sprite.set_position(130, 130)
         sprite.angle = 90
         self.coin_list.append(sprite)
 


### PR DESCRIPTION
Sprite.set_position calls Sprite._set_position with an extra self argument. This argument obviously should not be there ;-)

I fixed a few random bits trying to run all tests locally. This should make it behave better with newer versions of pytest and in Linux. (I did **not** manage to run the full test suite successfully, but it now passes more tests than before)