### PR TITLE
Add platforming multi-jump support

### DIFF
--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -83,6 +83,9 @@ class PhysicsEnginePlatformer:
         self.player_sprite = player_sprite
         self.platforms = platforms
         self.gravity_constant = gravity_constant
+        self.jumps_since_ground = 0
+        self.allowed_jumps = 1
+        self.support_multi_jump = False
 
     def can_jump(self) -> bool:
         """
@@ -100,10 +103,22 @@ class PhysicsEnginePlatformer:
 
         self.player_sprite.center_y += 2
 
-        if len(hit_list) > 0:
+        if len(hit_list) > 0 or (self.allow_multi_jump == True and
+                                 self.jumps_since_ground < self.allowed_jumps):
             return True
         else:
             return False
+    
+    def allow_multi_jump(self, allowed_jumps: int):
+        self.allowed_jumps = allowed_jumps
+        self.allow_multi_jump = True
+        
+    def increment_jump_counter(self):
+        """
+        Updates the jump counter for double-jump tracking
+        """
+        if self.allow_multi_jump:
+            self.jumps_since_ground += 1
 
     def update(self):
         """
@@ -128,6 +143,8 @@ class PhysicsEnginePlatformer:
                                                  self.player_sprite.top)
                 # print(f"Spot X ({self.player_sprite.center_x}, {self.player_sprite.center_y})")
             elif self.player_sprite.change_y < 0:
+                # Reset number of jumps
+                self.jumps_since_ground = 0
                 for item in hit_list:
                     while check_for_collision(self.player_sprite, item):
                         # self.player_sprite.bottom = item.top <- Doesn't work for ramps

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -85,7 +85,7 @@ class PhysicsEnginePlatformer:
         self.gravity_constant = gravity_constant
         self.jumps_since_ground = 0
         self.allowed_jumps = 1
-        self.support_multi_jump = False
+        self.allow_multi_jump = False
 
     def can_jump(self) -> bool:
         """
@@ -109,7 +109,7 @@ class PhysicsEnginePlatformer:
         else:
             return False
     
-    def allow_multi_jump(self, allowed_jumps: int):
+    def enable_multi_jump(self, allowed_jumps: int):
         self.allowed_jumps = allowed_jumps
         self.allow_multi_jump = True
         

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -115,7 +115,7 @@ class PhysicsEnginePlatformer:
         
     def increment_jump_counter(self):
         """
-        Updates the jump counter for double-jump tracking
+        Updates the jump counter for multi-jump tracking
         """
         if self.allow_multi_jump:
             self.jumps_since_ground += 1

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -103,8 +103,8 @@ class PhysicsEnginePlatformer:
 
         self.player_sprite.center_y += 2
 
-        if len(hit_list) > 0 or (self.allow_multi_jump == True and
-                                 self.jumps_since_ground < self.allowed_jumps):
+        if len(hit_list) > 0 or self.allow_multi_jump == True and\
+                                self.jumps_since_ground < self.allowed_jumps:
             return True
         else:
             return False
@@ -112,6 +112,11 @@ class PhysicsEnginePlatformer:
     def enable_multi_jump(self, allowed_jumps: int):
         self.allowed_jumps = allowed_jumps
         self.allow_multi_jump = True
+    
+    def disable_multi_jump(self):
+        self.allow_multi_jump = False
+        self.allowed_jumps = 1
+        self.jumps_since_ground = 0
         
     def increment_jump_counter(self):
         """

--- a/arcade/physics_engines.py
+++ b/arcade/physics_engines.py
@@ -110,10 +110,24 @@ class PhysicsEnginePlatformer:
             return False
     
     def enable_multi_jump(self, allowed_jumps: int):
+        """
+        Enables multi-jump.
+        allowed_jumps should include the initial jump.
+        (1 allows only a single jump, 2 enables double-jump, etc)
+
+        If you enable multi-jump, you MUST call increment_jump_counter()
+        every time the player jumps. Otherwise they can jump infinitely.
+        """
         self.allowed_jumps = allowed_jumps
         self.allow_multi_jump = True
     
     def disable_multi_jump(self):
+        """
+        Disables multi-jump.
+
+        Calling this function also removes the requirement to 
+        call increment_jump_counter() every time the player jumps.
+        """
         self.allow_multi_jump = False
         self.allowed_jumps = 1
         self.jumps_since_ground = 0

--- a/tests/unit2/test_physics_engine_platformer.py
+++ b/tests/unit2/test_physics_engine_platformer.py
@@ -42,11 +42,23 @@ class MyTestWindow(arcade.Window):
 
     def update(self, delta_time):
         self.physics_engine.update()
-        can_jump = self.physics_engine.can_jump()
-        # print(can_jump)
 
+def test_multi_jump(window):
+    window.physics_engine.enable_multi_jump(2)
+    window.physics_engine.jumps_since_ground = 0
+    assert window.physics_engine.can_jump() == True
+    window.character_sprite.change_y = 15
+    window.physics_engine.increment_jump_counter()
+    window.test()
+    assert window.physics_engine.can_jump() == True
+    window.character_sprite.change_y = 15
+    window.physics_engine.increment_jump_counter()
+    window.test()
+    assert window.physics_engine.can_jump() == False
+    window.physics_engine.disable_multi_jump()
 
 def test_main():
     window = MyTestWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Test Text")
     window.test()
+    test_multi_jump(window)
     window.close()


### PR DESCRIPTION
This adds arbitrary jump limits to the platforming physics engine. I created a different function to enable it because we don't want to assume the user wants to allow this functionality. Since it requires the user to update the jump counter themselves, if we default to a value of 1 for allowed_jumps, for example, then can_jump will break for users who don't add a call to increment_jump_counter. This would break existing code.

As written, this should allow existing code to continue working as-is, but it will require a user to call increment_jump_counter when they jump if they want to use this functionality.