### PR TITLE
Sprite default texture [Food for thought]

### DIFF
--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -173,7 +173,7 @@ class Texture:
         from arcade.sprite_list import SpriteList
 
         if self._sprite is None:
-            self._sprite = Sprite()
+            self._sprite = Sprite(width=width, height=height)
             self._sprite._texture = self
             self._sprite.textures = [self]
 
@@ -401,6 +401,43 @@ def make_soft_circle_texture(diameter: int, color: Color, center_alpha: int=255,
         clr = (color[0], color[1], color[2], alpha)
         draw.ellipse((center-radius, center-radius, center+radius, center+radius), fill=clr)
     name = "{}:{}:{}:{}:{}".format("soft_circle_texture", diameter, color, center_alpha, outer_alpha) # name must be unique for caching
+    return Texture(name, img)
+
+
+def make_solid_rectangle_texture(width: int, height: int, color: Color) -> Texture:
+    """Return a rectangular Texture.
+
+    Args:
+        :width (int): Width of Texture.
+        :height (int): Height of Texture.
+        :color (Color): Color of rectangle Texture.
+    Returns:
+        Solid rectangle texture.
+    """
+    img = PIL.Image.new("RGB", (int(width), int(height)), color)
+    name = "{}:{}:{}:{}".format("solidrect", width, height, color)
+    return Texture(name, img)
+
+
+def make_sprite_debug_texture(width: int, height: int, color: Color) -> Texture:
+    """Return a rectangular Texture for the purpose of sprite debug mode.
+
+    Args:
+        :width (int): Width of Texture.
+        :height (int): Height of Texture.
+        :color (Color): Color of rectangle Texture.
+    Returns:
+        Solid rectangle debug texture.
+    """
+    img = PIL.Image.new("RGB", (int(width), int(height)), (0, 0, 0, 0))
+    draw = PIL.ImageDraw.Draw(img, mode="RGB")
+    draw.rectangle((0, 0, img.width-2, img.height-2), outline=(0, 255, 0), width=1)
+    draw.line((img.width//2, img.height//2-5, img.width//2, img.height//2+5),
+              fill=(0, 255, 0), width=1)
+    draw.line((img.width//2-5, img.height//2, img.width//2+5, img.height//2),
+              fill=(0, 255, 0), width=1)
+
+    name = "{}:{}:{}:{}".format("solidrect", width, height, color)
     return Texture(name, img)
 
 

--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -713,7 +713,7 @@ class AnimatedTimeSprite(Sprite):
     Sprite for platformer games that supports animations.
     """
 
-    def __init__(self, image: Union[str, Texture]=None, scale: float = 1,
+    def __init__(self, image: Image=None, scale: float = 1,
                  width: float = 0, height: float = 0,
                  center_x: float = 0, center_y: float = 0):
 
@@ -740,7 +740,7 @@ class AnimatedWalkingSprite(Sprite):
     """
     Sprite for platformer games that supports animations.
     """
-    def __init__(self, image: Union[str, Texture]=None, scale: float = 1,
+    def __init__(self, image: Image=None, scale: float = 1,
                  width: float = 0, height: float = 0,
                  center_x: float = 0, center_y: float = 0):
         super().__init__(image=image, scale=scale, width=width, height=height,

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -251,14 +251,10 @@ def draw_text(text: str,
         draw.multiline_text((image_start_x, image_start_y), text, color, align=align, font=font)
         image = image.resize((width // scale_down, text_height // scale_down), resample=PIL.Image.LANCZOS)
 
-        text_sprite = Sprite()
-        text_sprite._texture = Texture(key)
-        text_sprite._texture.image = image
+        text_sprite = Sprite(Texture(key, image))
 
-        text_sprite.image = image
-        text_sprite.texture_name = key
-        text_sprite.width = image.width
-        text_sprite.height = image.height
+        # text_sprite.image = image  # TODO: what is this for?
+        # text_sprite.texture_name = key  # TODO: what is this for?
 
         if anchor_x == "left":
             text_sprite.center_x = start_x + text_sprite.width / 2

--- a/tests/unit2/test_animated_sprite.py
+++ b/tests/unit2/test_animated_sprite.py
@@ -21,7 +21,7 @@ class MyTestWindow(arcade.Window):
         self.character_list = arcade.SpriteList()
 
 
-        self.player = arcade.AnimatedWalkingSprite()
+        self.player = arcade.AnimatedWalkingSprite("../../arcade/examples/images/character_sprites/character0.png")
 
         character_scale = 1
         self.player.stand_right_textures = []
@@ -64,7 +64,8 @@ class MyTestWindow(arcade.Window):
 
         self.coin_list = arcade.SpriteList()
 
-        coin = arcade.AnimatedTimeSprite(scale=0.5)
+        coin = arcade.AnimatedTimeSprite(image="../../arcade/examples/images/gold_1.png",
+                                         scale=0.5)
         coin.center_x = 500
         coin.center_y = 500
 

--- a/tests/unit2/test_load_textures.py
+++ b/tests/unit2/test_load_textures.py
@@ -20,10 +20,15 @@ class MyTestWindow(arcade.Window):
 
         self.character_list = arcade.SpriteList()
 
-
-        self.player = arcade.AnimatedWalkingSprite()
-
+        raw_width = 59
+        raw_height = 97
         character_scale = 1
+
+        self.player = arcade.AnimatedWalkingSprite(
+            width=raw_width*character_scale,
+            height=raw_height*character_scale
+        )
+
         self.player.stand_right_textures = []
 
         self.player.stand_right_textures = arcade.load_textures("../../arcade/examples/images/character_sheet.png",
@@ -71,7 +76,9 @@ class MyTestWindow(arcade.Window):
 
         self.coin_list = arcade.SpriteList()
 
-        coin = arcade.AnimatedTimeSprite(scale=0.5)
+        coin = arcade.AnimatedTimeSprite(
+            image="../../arcade/examples/images/gold_1.png",
+            scale=0.5)
         coin.center_x = 500
         coin.center_y = 500
 

--- a/tests/unit2/test_sprite.py
+++ b/tests/unit2/test_sprite.py
@@ -6,10 +6,13 @@ SCREEN_HEIGHT = 600
 LINE_HEIGHT = 20
 CHARACTER_SCALING = 0.5
 
-class MyTestWindow(arcade.Window):
+FRAMES = 10
 
-    def __init__(self, width, height, title):
-        super().__init__(width, height, title)
+
+class GeneralTestWindow(arcade.Window):
+
+    def __init__(self):
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Test Window")
 
         file_path = os.path.dirname(os.path.abspath(__file__))
         os.chdir(file_path)
@@ -17,19 +20,13 @@ class MyTestWindow(arcade.Window):
         arcade.set_background_color(arcade.color.AMAZON)
 
         self.character_list = arcade.SpriteList()
-        self.character_sprite = arcade.Sprite("../../arcade/examples/images/character.png", CHARACTER_SCALING)
-        self.character_sprite.center_x = 50
-        self.character_sprite.center_y = 50
-        self.character_sprite.change_x = 5
-        self.character_sprite.change_y = 5
-        self.character_list.append(self.character_sprite)
-
         self.coin_list = arcade.SpriteList()
-        sprite = arcade.Sprite("../../arcade/examples/images/coin_01.png", CHARACTER_SCALING)
-        sprite.position = (130, 130)
-        sprite.set_position(130, 130)
-        sprite.angle = 90
-        self.coin_list.append(sprite)
+
+        self.setup()
+
+    def setup(self):
+        """To be overridden by specific test windows"""
+        pass
 
     def on_draw(self):
         arcade.start_render()
@@ -40,12 +37,110 @@ class MyTestWindow(arcade.Window):
         self.coin_list.update()
         self.character_list.update()
 
-        coin_hit_list = arcade.check_for_collision_with_list(self.character_sprite, self.coin_list)
-        for coin in coin_hit_list:
-            coin.kill()
-
 
 def test_sprite():
-    window = MyTestWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Test Text")
-    window.test()
+    class SpecificTestWindow(GeneralTestWindow):
+        def setup(self):
+            self.character_sprite = arcade.Sprite(
+                image="../../arcade/examples/images/character.png",
+                scale=CHARACTER_SCALING)
+            self.character_sprite.center_x = 50
+            self.character_sprite.center_y = 50
+            self.character_sprite.change_x = 5
+            self.character_sprite.change_y = 5
+            self.character_list.append(self.character_sprite)
+
+            sprite = arcade.Sprite(
+                image="../../arcade/examples/images/coin_01.png",
+                scale=CHARACTER_SCALING)
+            sprite.position = (130, 130)
+            sprite.set_position(130, 130)
+            sprite.angle = 90
+            self.coin_list.append(sprite)
+
+        def update(self, deltatime):
+            super().update(deltatime)
+            coin_hit_list = arcade.check_for_collision_with_list(
+                sprite=self.character_sprite,
+                sprite_list=self.coin_list)
+            for coin in coin_hit_list:
+                coin.kill()
+
+    window = SpecificTestWindow()
+    window.test(frames=FRAMES)
+    window.close()
+
+
+def test_sprite_image_crop():
+    """Should show small cutout of character's face as the texture."""
+    class SpecificTestWindow(GeneralTestWindow):
+        def setup(self):
+            cropped_texture = arcade.load_texture(
+                file_name="../../arcade/examples/images/character.png",
+                x=30,
+                y=28,
+                width=30,
+                height=30)
+            sprite = arcade.Sprite(
+                image=cropped_texture,
+                center_x=200,
+                center_y=200)
+            self.character_list.append(sprite)
+    window = SpecificTestWindow()
+    window.test(frames=FRAMES)
+    window.close()
+
+
+def test_scale_by_width_and_height():
+    """Should show texture very wide and very short."""
+    class SpecificTestWindow(GeneralTestWindow):
+        def setup(self):
+            sprite = arcade.Sprite(
+                "../../arcade/examples/images/character.png",
+                width=300,
+                height=50)
+            sprite.change_x = 3
+            sprite.change_y = 3
+            self.character_list.append(sprite)
+    window = SpecificTestWindow()
+    window.test(frames=FRAMES)
+    window.close()
+
+
+def test_scale_by_width_and_height_then_scale_property():
+    """Should show texture very wide and very short.
+    just scaled down by half."""
+    class SpecificTestWindow(GeneralTestWindow):
+        def setup(self):
+            sprite = arcade.Sprite(
+                image="../../arcade/examples/images/character.png",
+                width=300,
+                height=50)
+            sprite.scale = 0.5  # scale down
+            sprite.change_x = 3
+            sprite.change_y = 3
+            self.character_list.append(sprite)
+    window = SpecificTestWindow()
+    window.test(frames=FRAMES)
+    window.close()
+
+    assert window.character_list[0].width == 300 * 0.5
+    assert window.character_list[0].height == 50 * 0.5
+
+
+def test_give_width_and_height_and_scale():
+    """Should set width and height, then size up/down according to scale
+    Should show very tall and very thin, yet, scaled up significantly."""
+    class SpecificTestWindow(GeneralTestWindow):
+        def setup(self):
+            sprite = arcade.Sprite(
+                image="../../arcade/examples/images/character.png",
+                width=10,
+                height=100,
+                scale=5)
+            sprite.change_x = 3
+            sprite.change_y = 3
+            self.character_list.append(sprite)
+    window = SpecificTestWindow()
+    window.test(frames=FRAMES)
     window.close()

--- a/tests/unit2/test_sprite.py
+++ b/tests/unit2/test_sprite.py
@@ -1,4 +1,5 @@
 import os
+import random
 import arcade
 
 SCREEN_WIDTH = 800
@@ -91,56 +92,97 @@ def test_sprite_image_crop():
     window.close()
 
 
-def test_scale_by_width_and_height():
-    """Should show texture very wide and very short."""
+def test_adding_image_after_creation_should_not_leave_a_tint():
     class SpecificTestWindow(GeneralTestWindow):
-        def setup(self):
-            sprite = arcade.Sprite(
-                "../../arcade/examples/images/character.png",
-                width=300,
-                height=50)
-            sprite.change_x = 3
-            sprite.change_y = 3
-            self.character_list.append(sprite)
+        def __init__(self):
+            super().__init__()
+            self.frame_count = 0
+            self.character_sprite = arcade.Sprite(width=50,
+                                                  height=50,
+                                                  color=(0, 0, 0))
+            self.character_sprite.center_x = 150
+            self.character_sprite.center_y = 150
+            self.character_list.append(self.character_sprite)
+
+        def update(self, delta_time):
+            super().update(delta_time)
+            self.frame_count += 1
+
+            if self.frame_count == 10:
+                self.character_sprite.texture = arcade.load_texture(
+                    "../../arcade/examples/images/character.png")
+
     window = SpecificTestWindow()
-    window.test(frames=FRAMES)
+    window.test(frames=20)
     window.close()
 
 
-def test_scale_by_width_and_height_then_scale_property():
-    """Should show texture very wide and very short.
-    just scaled down by half."""
+def test_debug_mode_with_image():
+    """Should show a bunch of sprites flying around in debug mode."""
     class SpecificTestWindow(GeneralTestWindow):
-        def setup(self):
-            sprite = arcade.Sprite(
+        def __init__(self):
+            super().__init__()
+            self.frame_count = 0
+            self.character_sprite = arcade.Sprite(
                 image="../../arcade/examples/images/character.png",
-                width=300,
-                height=50)
-            sprite.scale = 0.5  # scale down
-            sprite.change_x = 3
-            sprite.change_y = 3
-            self.character_list.append(sprite)
+                scale=1)
+            self.character_sprite.center_x = 150
+            self.character_sprite.center_y = 150
+            self.character_sprite.change_x = 3
+            self.character_sprite.change_y = 3
+            self.character_list.append(self.character_sprite)
+            assert self.character_sprite.debug is False
+
+            for _ in range(100):
+                coin = arcade.Sprite(
+                    image="../../arcade/examples/images/coin_01.png",
+                    scale=CHARACTER_SCALING)
+                coin.center_x = random.randrange(0, SCREEN_WIDTH)
+                coin.center_y = random.randrange(0, SCREEN_HEIGHT)
+                while coin.change_x == 0 and coin.change_y == 0:
+                    coin.change_x = random.randrange(-5, 5)
+                    coin.change_y = random.randrange(-5, 5)
+                coin.debug = True
+                self.coin_list.append(coin)
+
+        def update(self, delta_time):
+            super().update(delta_time)
+            self.frame_count += 1
+
+            if self.frame_count == 10:
+                self.character_sprite.debug = True
+
     window = SpecificTestWindow()
-    window.test(frames=FRAMES)
+    window.test(frames=20)
     window.close()
 
-    assert window.character_list[0].width == 300 * 0.5
-    assert window.character_list[0].height == 50 * 0.5
 
-
-def test_give_width_and_height_and_scale():
-    """Should set width and height, then size up/down according to scale
-    Should show very tall and very thin, yet, scaled up significantly."""
+def test_switch_debug_mode_with_image():
+    """Should show character moving to the right switching on and off
+    between debug mode."""
     class SpecificTestWindow(GeneralTestWindow):
-        def setup(self):
-            sprite = arcade.Sprite(
+        def __init__(self):
+            super().__init__()
+            self.frame_count = 0
+            self.character_sprite = arcade.Sprite(
                 image="../../arcade/examples/images/character.png",
-                width=10,
-                height=100,
-                scale=5)
-            sprite.change_x = 3
-            sprite.change_y = 3
-            self.character_list.append(sprite)
+                scale=0.5)
+            self.character_sprite.center_x = 150
+            self.character_sprite.center_y = 150
+            self.character_sprite.change_x = 3
+            self.character_list.append(self.character_sprite)
+
+        def update(self, delta_time):
+            super().update(delta_time)
+            self.frame_count += 1
+
+            if self.frame_count == 30:
+                self.character_sprite.debug = True
+            elif self.frame_count == 60:
+                self.character_sprite.debug = False
+            elif self.frame_count == 90:
+                self.character_sprite.debug = True
+
     window = SpecificTestWindow()
-    window.test(frames=FRAMES)
+    window.test(frames=120)
     window.close()

--- a/tests/unit2/test_sprite_default_texture.py
+++ b/tests/unit2/test_sprite_default_texture.py
@@ -1,0 +1,75 @@
+import os
+import random
+
+import arcade
+import pytest
+
+
+SCREEN_WIDTH = 800
+SCREEN_HEIGHT = 600
+LINE_HEIGHT = 20
+CHARACTER_SCALING = 0.5
+
+FRAMES = 50
+
+
+class GeneralTestWindow(arcade.Window):
+
+    def __init__(self):
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Test Window")
+
+        file_path = os.path.dirname(os.path.abspath(__file__))
+        os.chdir(file_path)
+
+        arcade.set_background_color(arcade.color.AMAZON)
+
+        self.all_sprites = arcade.SpriteList()
+
+        self.setup()
+
+    def setup(self):
+        """To be overridden by specific test windows"""
+        pass
+
+    def on_draw(self):
+        arcade.start_render()
+        self.all_sprites.draw()
+
+    def update(self, delta_time):
+        self.all_sprites.update()
+
+
+def test_no_image_no_dimensions_raises_value_error():
+    """When no dimensions are given, raise ValueError."""
+    with pytest.raises(ValueError):
+        self.character_sprite = arcade.Sprite()
+
+
+def test_no_image_with_dimensions_draws_default_texture():
+    """Use a default rectangle texture when no texture is given.
+    Random color if not specified."""
+    class SpecificTestWindow(GeneralTestWindow):
+        def setup(self):
+            self.character_sprite = arcade.Sprite(
+                width=100,
+                height=100,
+                color=arcade.color.BLUE)
+            self.character_sprite.center_x = 50
+            self.character_sprite.center_y = 50
+            self.character_sprite.change_x = 5
+            self.character_sprite.change_y = 5
+            self.all_sprites.append(self.character_sprite)
+
+            for _ in range(100):
+                sprite = arcade.Sprite(width=20, height=20)
+                sprite.center_x = random.randrange(10, SCREEN_WIDTH-10)
+                sprite.center_y = random.randrange(10, SCREEN_HEIGHT-10)
+                while sprite.change_x == 0 and sprite.change_y == 0:
+                    sprite.change_x = random.randrange(-4, 5)
+                    sprite.change_y = random.randrange(-4, 5)
+
+                self.all_sprites.append(sprite)
+
+    window = SpecificTestWindow()
+    window.test(frames=FRAMES)
+    window.close()

--- a/tests/unit2/test_sprite_scale.py
+++ b/tests/unit2/test_sprite_scale.py
@@ -6,31 +6,135 @@ SCREEN_HEIGHT = 600
 LINE_HEIGHT = 20
 CHARACTER_SCALING = 0.5
 
-class MyTestWindow(arcade.Window):
+FRAMES = 50
 
-    def __init__(self, width, height, title):
-        super().__init__(width, height, title)
 
-        file_path = os.path.dirname(os.path.abspath(__file__))
-        os.chdir(file_path)
+file_path = os.path.dirname(os.path.abspath(__file__))
+os.chdir(file_path)
 
+
+class GeneralTestWindow(arcade.Window):
+    def __init__(self):
+        super().__init__(SCREEN_WIDTH, SCREEN_HEIGHT, "Test Window")
         arcade.set_background_color(arcade.color.AMAZON)
-
         self.character_list = arcade.SpriteList()
-        self.character_sprite = arcade.Sprite("../../arcade/examples/images/character.png", CHARACTER_SCALING)
-        self.character_sprite.center_x = 150
-        self.character_sprite.center_y = 150
-        self.character_list.append(self.character_sprite)
+
+    def update(self, delta_time):
+        self.character_list.update()
 
     def on_draw(self):
         arcade.start_render()
         self.character_list.draw()
 
-    def update(self, delta_time):
-        self.character_sprite.scale += 0.1
 
+def test_sprite_grows_when_increasing_scale():
+    """Should show character image in lower left, growing in size."""
+    class SpecificTestWindow(GeneralTestWindow):
+        def __init__(self):
+            super().__init__()
+            self.character_sprite = arcade.Sprite(
+                image="../../arcade/examples/images/character.png",
+                scale=CHARACTER_SCALING)
+            self.character_sprite.center_x = 150
+            self.character_sprite.center_y = 150
+            self.character_list.append(self.character_sprite)
 
-def test_sprite():
-    window = MyTestWindow(SCREEN_WIDTH, SCREEN_HEIGHT, "Test Text")
+        def update(self, delta_time):
+            super().update(delta_time)
+            self.character_sprite.scale += 0.1
+
+    window = SpecificTestWindow()
     window.test()
+    window.close()
+
+
+def test_sprite_without_image_grows_when_increasing_scale():
+    """Should show a black square texture growing in the bottom left."""
+    class SpecificTestWindow(GeneralTestWindow):
+        def __init__(self):
+            super().__init__()
+            self.character_sprite = arcade.Sprite(width=20,
+                                                  height=20,
+                                                  color=(0, 0, 0))
+            self.character_sprite.center_x = 150
+            self.character_sprite.center_y = 150
+            self.character_list.append(self.character_sprite)
+
+        def update(self, delta_time):
+            super().update(delta_time)
+            self.character_sprite.scale += 0.1
+
+    window = SpecificTestWindow()
+    window.test()
+    window.close()
+
+
+def test_setting_width_will_reset_scale_to_1():
+    """Should show red square growing in scale.
+    When it gets to be 100 px, the width will be reset to 50
+    and continue to grow again to 100px"""
+    class SpecificTestWindow(GeneralTestWindow):
+        def __init__(self):
+            super().__init__()
+            self.character_sprite = arcade.Sprite(width=50,
+                                                  height=50,
+                                                  color=(255, 0, 0))
+            self.character_sprite.center_x = 150
+            self.character_sprite.center_y = 150
+            self.character_list.append(self.character_sprite)
+
+        def update(self, delta_time):
+            super().update(delta_time)
+            self.character_sprite.scale += 0.1
+            if self.character_sprite.width > 100:
+                self.character_sprite.width = 50
+                self.character_sprite.height = 50
+
+    window = SpecificTestWindow()
+    window.test(frames=FRAMES)
+    window.close()
+
+
+def test_scale_by_width_and_height():
+    """Should show texture very wide and very short.
+    Moving up and to the right"""
+    class SpecificTestWindow(GeneralTestWindow):
+        def __init__(self):
+            super().__init__()
+            sprite = arcade.Sprite(
+                "../../arcade/examples/images/character.png",
+                width=300,
+                height=50)
+            sprite.change_x = 3
+            sprite.change_y = 3
+            self.character_list.append(sprite)
+
+    window = SpecificTestWindow()
+    window.test(frames=FRAMES)
+    window.close()
+
+
+def test_set_width_then_scale_maintains_ratio():
+    sprite = arcade.Sprite(width=100, height=50)
+    sprite.scale = 0.5
+    assert sprite.width == 50
+    assert sprite.height == 25
+
+
+def test_give_width_and_height_and_scale():
+    """Should set width and height, then size up/down according to scale
+    Should show very tall and very thin, yet, scaled up significantly."""
+    class SpecificTestWindow(GeneralTestWindow):
+        def __init__(self):
+            super().__init__()
+            sprite = arcade.Sprite(
+                image="../../arcade/examples/images/character.png",
+                width=10,
+                height=100,
+                scale=5)
+            sprite.change_x = 3
+            sprite.change_y = 3
+            self.character_list.append(sprite)
+    window = SpecificTestWindow()
+    window.test(frames=FRAMES)
     window.close()


### PR DESCRIPTION
I was messing around with a new concept for the `Sprite` class. The idea came when I noticed that the  `Sprite` class wasn't useful without access to an image file. In the event a Sprite is created without an image, I wanted the `Sprite` class, by default, to have a simple rectangle texture created, either with a supplied color, or with a random color. This beats having arcade constantly make calls to `arcade.draw_rectangle`, which causes the program to slow down significantly.  With this "default texture" idea, came significant changes to the `Sprite` class we might want to discuss.

- Abstract out cropping images when creating sprites.
  Removed `image_x`, `image_y`, `image_width`, and `image_height`
  arguments, as they are for cropping.
  Cropping should be done with `load_image()` and the resulting
  `Texture` object should be given to a `Sprite`.

- Sprites now accept Textures (as well as the traditional file name) upon creation.
  Changed Sprite kwarg `filename` to `image`, to be more general
  when accepting both file names and `Texture` objects. We could 
  still allow a `filename` key-word argument so code that
  explicitly uses it when creating a sprite doesn't break.

- `width` and `height` properties allow more precision of the size
  of the Sprite. Can be used in conjunction with or independently
  from the scale property.

- Added `Sprite.debug` property which switches out the current texture for a black box with green border and croshair in `center_x`, `center_y` for better visualization. Especially if the original image is not cropped properly and is causing far-off collisions. The aesthetic of this could be better implemented with a translucent black overlay on the original texture with the bounding box and cross-hair. What I have now is just a prototype.