### PR TITLE
Fix make_circle_texture to draw within bounding box.

### DIFF
--- a/arcade/draw_commands.py
+++ b/arcade/draw_commands.py
@@ -369,9 +369,7 @@ def make_circle_texture(diameter: int, color: Color) -> Texture:
     bg_color = (0, 0, 0, 0) # fully transparent
     img = PIL.Image.new("RGBA", (diameter, diameter), bg_color)
     draw = PIL.ImageDraw.Draw(img)
-    radius = int(diameter // 2)
-    center = radius # for readability
-    draw.ellipse((radius, radius, center+radius, center+radius), fill=color)
+    draw.ellipse((0, 0, diameter-1, diameter-1), fill=color)
     name = "{}:{}:{}".format("circle_texture", diameter, color) # name must be unique for caching
     return Texture(name, img)
 
@@ -399,7 +397,7 @@ def make_soft_circle_texture(diameter: int, color: Color, center_alpha: int=255,
     for radius in range(max_radius, 0, -1):
         alpha = int(lerp(center_alpha, outer_alpha, radius/max_radius))
         clr = (color[0], color[1], color[2], alpha)
-        draw.ellipse((center-radius, center-radius, center+radius, center+radius), fill=clr)
+        draw.ellipse((center-radius, center-radius, center+radius-1, center+radius-1), fill=clr)
     name = "{}:{}:{}:{}:{}".format("soft_circle_texture", diameter, color, center_alpha, outer_alpha) # name must be unique for caching
     return Texture(name, img)
 


### PR DESCRIPTION
The Pillow method [`.ellipse()`](https://pillow.readthedocs.io/en/3.1.x/reference/ImageDraw.html#PIL.ImageDraw.PIL.ImageDraw.Draw.ellipse) takes points as a bounding box, rather than origin plus radius.

Also, adjusted `make_soft_circle_texture` to draw within bounding box (circles were getting clipped one pixel).