### PR TITLE
[WIP] Add collision methods to Sprite (with tests)

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -13,7 +13,7 @@ from arcade.draw_commands import load_texture
 from arcade.draw_commands import draw_texture_rectangle
 from arcade.draw_commands import Texture
 from arcade.draw_commands import rotate_point
-from arcade.arcade_types import RGB
+from arcade.arcade_types import RGB, Point
 
 from typing import Sequence
 from typing import Tuple
@@ -666,6 +666,49 @@ class Sprite:
         Alias of `remove_from_sprite_lists`
         """
         self.remove_from_sprite_lists()
+
+    def collides_with_point(self, point: Point) -> bool:
+        """Check if point is within the current sprite.
+
+        Args:
+            self: Current sprite
+            point: Point to check.
+
+        Returns:
+            True if the point is contained within the sprite's boundary.
+        """
+        from arcade.geometry import is_point_in_polygon
+
+        x, y = point
+        return is_point_in_polygon(x, y, self.points)
+
+    def collides_with_sprite(self, other: 'Sprite') -> bool:
+        """Will check if a sprite is overlapping (colliding) another Sprite.
+
+        Args:
+            self: Current Sprite.
+            other: The other sprite to check against.
+
+        Returns:
+            True or False, whether or not they are overlapping.
+        """
+        from arcade.geometry import check_for_collision
+
+        return check_for_collision(self, other)
+
+    def collides_with_list(self, sprite_list: list) -> list:
+        """Check if current sprite is overlapping with any other sprite in a list
+
+        Args:
+            self: current Sprite
+            sprite_list: SpriteList to check against
+
+        Returns:
+            SpriteList of all overlapping Sprites from the original SpriteList
+        """
+        from arcade.sprite_list import SpriteList
+        from arcade.geometry import check_for_collision_with_list
+        return check_for_collision_with_list(self, sprite_list)
 
 
 class AnimatedTimeSprite(Sprite):

--- a/tests/unit2/test_sprite_collision.py
+++ b/tests/unit2/test_sprite_collision.py
@@ -1,4 +1,11 @@
+import os
+
 import arcade
+
+
+file_path = os.path.dirname(os.path.abspath(__file__))
+os.chdir(file_path)
+
 
 def test_sprites_at_point():
 
@@ -14,3 +21,70 @@ def test_sprites_at_point():
 
     sprite_list = arcade.get_sprites_at_point((140, 130), coin_list)
     assert len(sprite_list) == 1
+
+
+def test_sprite_collides_with_point():
+    sprite = arcade.Sprite(center_x=0, center_y=0)
+    sprite.width = 2
+    sprite.height = 2
+
+    # Affirmative
+    point = (0, 0)
+    assert sprite.collides_with_point(point) is True
+    point = (1, 1)
+    assert sprite.collides_with_point(point) is True
+    point = (0, 1)
+    assert sprite.collides_with_point(point) is True
+    point = (1, 0)
+    assert sprite.collides_with_point(point) is True
+
+    # Negative
+    point = (-1, -1)
+    assert sprite.collides_with_point(point) is False
+    point = (-1, 0)
+    assert sprite.collides_with_point(point) is False
+    point = (2, 2)
+    assert sprite.collides_with_point(point) is False
+
+
+def test_sprite_collides_with_sprite():
+    sprite_one = arcade.Sprite(center_x=0, center_y=0)
+    sprite_one.width = 10
+    sprite_one.height = 10
+
+    sprite_two = arcade.Sprite(center_x=5, center_y=5)
+    sprite_two.width = 10
+    sprite_two.height = 10
+
+    assert sprite_one.collides_with_sprite(sprite_two) is True
+
+    sprite_one.center_x = -5
+    assert sprite_one.collides_with_sprite(sprite_two) is False
+
+
+def test_sprite_collides_with_list():
+    coins = arcade.SpriteList()
+    for x in range(0, 50, 10):
+        coin = arcade.Sprite(center_x=x, center_y=0)
+        coin.width = 10
+        coin.height = 10
+        coins.append(coin)
+
+    player = arcade.Sprite(center_x=100, center_y=100)
+    player.width = 10
+    player.height = 10
+
+    # collides with none
+    result = player.collides_with_list(coins)
+    assert len(result) == 0, "Should return empty list"
+
+    # collides with one
+    player.center_x = -5
+    player.center_y = 0
+    result = player.collides_with_list(coins)
+    assert len(result) == 1, "Should collide with one"
+
+    # collides with two
+    player.center_x = 5
+    result = player.collides_with_list(coins)
+    assert len(result) == 2, "Should collide with two"


### PR DESCRIPTION
done:
- `sprite.collides_with_point(self, point: Point) -> bool`
- `sprite.collides_with_sprite(self, other: 'Sprite') -> bool`
- `sprite.collides_with_list(self, sprite_list: list) -> list`

todo:
- Add `sprite_list.collides_with_point(point: Point) -> bool`
- Add `sprite_list.collides_with_sprite(sprite: Sprite) -> bool`

Wondering:
1. In the Sprite methods, I needed to import functions (e.g., `from arcade.geometry import check_for_collision`) to avoid circular imports that were crashing the program. Is this acceptable?
2. Is it worth making a general `Sprite.collides_with(other: Union(Point, Sprite, SpriteList)) -> Union(bool, SpriteList)` function that, depending on the provided argument, will call the appropriate function to allow for:
    ```python
    if sprite_one.collides_with(point):
        pass
    
    if sprite_one.collides_with(sprite_two):
        pass

    for collided in sprite_one.collides_with(bunch_of_sprites):
        pass
    ````

Will eventually Resolve #430 