### PR TITLE
Travis CI: Reenable pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,17 @@
+dist: xenial
 language: python
-install: pip install flake8
-script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+python: 3.7
+services: xvfb
+addons:
+  apt:
+    update: true
+    packages:
+    - freeglut3-dev
+    - python3-gi
+    - python3-gi-cairo
+    - python-gst-1.0
+before_install: pip install --upgrade pip
+install: pip install -r requirements.txt -r requirements_dev.txt
+before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+script: pytest
+after_success: coveralls

--- a/arcade/examples/perf_test/stress_test_draw_moving_pygame.py
+++ b/arcade/examples/perf_test/stress_test_draw_moving_pygame.py
@@ -16,6 +16,8 @@ import timeit
 import time
 import collections
 
+import matplotlib.pyplot as plt
+
 # Define some colors
 BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)

--- a/arcade/examples/text_loc_example_done.py
+++ b/arcade/examples/text_loc_example_done.py
@@ -21,6 +21,7 @@ gettext.install('text_loc_example', localedir='text_loc_example_locale')
 SCREEN_WIDTH = 500
 SCREEN_HEIGHT = 500
 SCREEN_TITLE = "Localizing Text Example"
+_ = gettext.gettext
 
 
 class MyGame(arcade.Window):

--- a/doc/examples/install_requires.py
+++ b/doc/examples/install_requires.py
@@ -1,3 +1,5 @@
+# flake8: noqa
+
 setup(
     ...
     install_requires=[

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Pyglet==1.4.0b1
-Pillow
 numpy
+Pillow
+Pyglet>=1.4.1
 pyglet-ffmpeg2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,10 @@
 -e .
-pytest
-sphinx
 coverage
 coveralls
-sphinx_rtd_theme
-setuptools
+flake8
+pytest
 pytest-cov
 pytest-mock
+setuptools
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
__XlibScreen(display=<pyglet.canvas.xlib.XlibDisplay object at 0x7f9778ae6320>, x=0, y=0, width=1024, height=768, xinerama=0)__ is being created in Travis CI but __get_matching_configs()__ is failing to return any configs for the template:
```
template = XlibConfig([('double_buffer', True),
 ('stereo', None),
 ('buffer_size', None),
 ('aux_buffers', None),
 ('sample_buff...cum_alpha_size', None),
 ('major_version', 3),
 ('minor_version', 3),
 ('forward_compatible', None),
 ('debug', None)])
```

Are __'major_version', 3 and 'minor_version', 3__ the correct values?