### PR TITLE
Travis CI: Run all tests on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,5 +34,7 @@ install:
   - pip3 install --upgrade pip
   - pip3 install -r requirements.txt -r requirements_dev.txt
 before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-script: pytest --ignore=tests/unit2  # TODO: remove the --ignore
+script:
+  - pytest --ignore=tests/unit2  # TODO: remove the --ignore
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then pytest tests/unit2; fi
 after_success: coveralls


### PR DESCRIPTION
masOS has builtin OpenGL support so we can run the __tests/unit2__.

__if [ "$TRAVIS_OS_NAME" == "osx" ]; then pytest tests/unit2; fi__