### PR TITLE
raise better error on dataclasses missing

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -7,7 +7,10 @@ https://www.gamedev.net/articles/programming/general-and-gameplay-programming/sp
 
 
 import math
-import dataclasses
+try:
+    import dataclasses
+except ModuleNotFoundError:
+    raise Exception('dataclasses not available, if running on Python 3.6 please manually install https://pypi.org/project/dataclasses/')
 
 import PIL.Image
 


### PR DESCRIPTION
#469 
Small change to raise a better error when using python 3.6.

There might be a better way to do it but I thought I would try my hand at a PR since it was easy.