### PR TITLE
require dataclasses on python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 language: python
-python: 3.7
+python:
+  - '3.6'
+  - '3.7'
 services: xvfb
 matrix:
   include:
     - name: "Python 3.7 on xenial"
+      python: '3.7'
       dist: xenial
     - name: "Python 3.7 on bionic"
+      python: '3.7'
       dist: bionic
     - name: "Python 3.7 on macOS"
+      python: '3.7'
       os: osx
       osx_image: xcode11
       language: minimal
       before_install: sw_vers
     - name: "Python 3.7 on Windows"
+      python: '3.7'
       os: windows
       language: bash
       before_install:

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,16 @@ RELEASE = VERSION
 
 if __name__ == "__main__":
 
+    install_requires = [
+        'pyglet',
+        'pillow',
+        'numpy',
+        'pyglet-ffmpeg2',
+        'pytiled-parser'
+    ]
+    if sys.version_info[0] == 3 and sys.version_info[1] == 6:
+        install_requires.append('dataclasses')
+
     if "--format=msi" in sys.argv or "bdist_msi" in sys.argv:
         # hack the version name to a format msi doesn't have trouble with
         VERSION = VERSION.replace("-alpha", "a")
@@ -30,19 +40,14 @@ if __name__ == "__main__":
           license="MIT",
           url="http://arcade.academy",
           download_url="http://arcade.academy",
-          install_requires=[
-            'pyglet',
-            'pillow',
-            'numpy',
-            'pyglet-ffmpeg2',
-            'pytiled-parser'
-          ],
+          install_requires=install_requires,
           packages=["arcade",
                     "arcade.key",
                     "arcade.color",
                     "arcade.csscolor",
                     "arcade.examples"
                     ],
+          python_requires='>=3.6',
           classifiers=[
               "Development Status :: 5 - Production/Stable",
               "Intended Audience :: Developers",


### PR DESCRIPTION
Closes #469
Refs #471

You could also expand the test matrix to test on python 3.6 on a wider variety of platforms, if you wanted.