### PR TITLE
Tile Set Support for TMX

### DIFF
--- a/arcade/sprite.py
+++ b/arcade/sprite.py
@@ -102,8 +102,8 @@ class Sprite:
         Args:
             filename (str): Filename of an image that represents the sprite.
             scale (float): Scale the image up or down. Scale of 1.0 is none.
-            image_x (float): Scale the image up or down. Scale of 1.0 is none.
-            image_y (float): Scale the image up or down. Scale of 1.0 is none.
+            image_x (float): X offset to sprite within sprite sheet.
+            image_y (float): Y offset to sprite within sprite sheet.
             image_width (float): Width of the sprite
             image_height (float): Height of the sprite
             center_x (float): Location of the sprite


### PR DESCRIPTION
Support tilesets from tmx files.

Prior implementation required the use of a "collection of images" when using a TMX.  This patch adds support for tilesets.  Key changes relative to a collection of images that happen when working with a tile set:
* The `image` is defined in the top level tileset,
* Individual `tiles` are only defined if they add custom data (such as a non-standard bounding box), and
* The sprite must be cropped out of the top level image.

This is accomplished by:
* Creating "virtual" tiles when needed for sprites from a tile set,
* Manually setting the top level `image` in the tile for any sprite from a tile set, and
* Explicitly passing cropping data when creating a sprite from a `tile`.

This closes #511.