### PR TITLE
Fix missing return in get system mouse cursor

### DIFF
--- a/arcade/application.py
+++ b/arcade/application.py
@@ -512,7 +512,7 @@ class Window(pyglet.window.Window):
         super().set_exclusive_keyboard(exclusive)
 
     def get_system_mouse_cursor(self, name):
-        super().get_system_mouse_cursor(name)
+        return super().get_system_mouse_cursor(name)
 
     def dispatch_events(self):
         super().dispatch_events()


### PR DESCRIPTION
Currently method `get_system_mouse_cursor` is returning `None` instead of the cursor instance