### PR TITLE
Allow getting tmx layer by path

### DIFF
--- a/arcade/examples/tmx_object_demo.py
+++ b/arcade/examples/tmx_object_demo.py
@@ -1,0 +1,110 @@
+import arcade
+
+"""
+Starting Template
+
+Once you have learned how to use classes, you can begin your program with this
+template.
+
+If Python and Arcade are installed, this example can be run from the command line with:
+python -m arcade.examples.starting_template
+"""
+import arcade
+
+SCREEN_WIDTH = 800
+SCREEN_HEIGHT = 600
+SCREEN_TITLE = "Starting Template"
+
+TILE_SCALING = .25
+
+class MyGame(arcade.Window):
+    """
+    Main application class.
+
+    NOTE: Go ahead and delete the methods you don't need.
+    If you do need a method, delete the 'pass' and replace it
+    with your own code. Don't leave 'pass' in this program.
+    """
+
+    def __init__(self, width, height, title):
+        super().__init__(width, height, title)
+
+        arcade.set_background_color(arcade.color.AMAZON)
+
+        # If you have sprite lists, you should create them here,
+        # and set them to None
+
+    def setup(self):
+        # Create your sprites and sprite lists here
+        map_name = ":resources:/tmx_maps/test_objects.tmx"
+
+        # Read in the tiled map
+        my_map = arcade.tilemap.read_tmx(map_name)
+
+        self.tile_list = arcade.tilemap.process_layer(my_map, 'Tiles', TILE_SCALING)
+        self.tile_list_2 = arcade.tilemap.process_layer(my_map, 'Group/Tiles', TILE_SCALING)
+
+    def on_draw(self):
+        """
+        Render the screen.
+        """
+
+        # This command should happen before we start drawing. It will clear
+        # the screen to the background color, and erase what we drew last frame.
+        arcade.start_render()
+
+        # Call draw() on all your sprite lists below
+        self.tile_list_2.draw()
+        self.tile_list.draw()
+
+    def on_update(self, delta_time):
+        """
+        All the logic to move, and the game logic goes here.
+        Normally, you'll call update() on the sprite lists that
+        need it.
+        """
+        pass
+
+    def on_key_press(self, key, key_modifiers):
+        """
+        Called whenever a key on the keyboard is pressed.
+
+        For a full list of keys, see:
+        http://arcade.academy/arcade.key.html
+        """
+        pass
+
+    def on_key_release(self, key, key_modifiers):
+        """
+        Called whenever the user lets off a previously pressed key.
+        """
+        pass
+
+    def on_mouse_motion(self, x, y, delta_x, delta_y):
+        """
+        Called whenever the mouse moves.
+        """
+        pass
+
+    def on_mouse_press(self, x, y, button, key_modifiers):
+        """
+        Called when the user presses a mouse button.
+        """
+        pass
+
+    def on_mouse_release(self, x, y, button, key_modifiers):
+        """
+        Called when a user releases a mouse button.
+        """
+        pass
+
+
+def main():
+    """ Main method """
+    game = MyGame(SCREEN_WIDTH, SCREEN_HEIGHT, SCREEN_TITLE)
+    game.setup()
+    arcade.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/arcade/resources/tmx_maps/test_objects.tmx
+++ b/arcade/resources/tmx_maps/test_objects.tmx
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.3.3" orientation="orthogonal" renderorder="right-down" width="20" height="20" tilewidth="128" tileheight="128" infinite="0" backgroundcolor="#55aa7f" nextlayerid="7" nextobjectid="13">
+ <tileset firstgid="1" source="standard_tileset.tsx"/>
+ <objectgroup id="2" name="Shapes">
+  <object id="1" x="504.89" y="630.365" width="573.603" height="469.04"/>
+  <object id="2" x="1195.01" y="794.678">
+   <point/>
+  </object>
+  <object id="3" x="1195.01" y="794.678">
+   <point/>
+  </object>
+  <object id="5" x="1284.63" y="513.852" width="558.665" height="510.865">
+   <ellipse/>
+  </object>
+  <object id="6" x="950.029" y="1392.18">
+   <polygon points="0,0 224.063,678.165 836.504,8.96254"/>
+  </object>
+ </objectgroup>
+ <objectgroup id="4" name="Text" locked="1">
+  <object id="10" x="836.621" y="89.0878" width="426.979" height="120.576">
+   <text fontfamily="Sans Serif" pixelsize="64" wrap="1">Hello World</text>
+  </object>
+ </objectgroup>
+ <group id="5" name="Group">
+  <objectgroup id="6" name="Tiles" opacity="0.5">
+   <object id="11" gid="11" x="800" y="1500" width="600" height="400" rotation="45"/>
+   <object id="12" gid="11" x="1400" y="1600" width="600" height="400"/>
+  </objectgroup>
+ </group>
+ <objectgroup id="3" name="Tiles">
+  <object id="7" name="crate1" type="crate" gid="1" x="1500" y="1800" width="400" height="1000" rotation="-45"/>
+  <object id="8" name="coin1" type="coin" gid="2" x="1400" y="1800" width="700" height="700"/>
+ </objectgroup>
+</map>

--- a/arcade/tilemap.py
+++ b/arcade/tilemap.py
@@ -78,11 +78,10 @@ def get_tilemap_layer(map_object: pytiled_parser.objects.TileMap,
     assert isinstance(layer_path, str)
 
     def _get_tilemap_layer(path, layers):
-        layer_name = path[0]
+        layer_name = path.pop(0)
         for layer in layers:
             if layer.name == layer_name:
-                if layer.__class__ is pytiled_parser.objects.LayerGroup:
-                    path.pop(0)
+                if isinstance(layer, pytiled_parser.objects.LayerGroup):
                     return _get_tilemap_layer(path, layer.layers)
                 else:
                     return layer

--- a/arcade/tilemap.py
+++ b/arcade/tilemap.py
@@ -62,28 +62,35 @@ def read_tmx(tmx_file: str) -> pytiled_parser.objects.TileMap:
 
     return tile_map
 
-
 def get_tilemap_layer(map_object: pytiled_parser.objects.TileMap,
-                      layer_name: str) -> Optional[pytiled_parser.objects.Layer]:
+                      layer_path: str) -> Optional[pytiled_parser.objects.Layer]:
     """
-    Given a TileMap and a layer name, this returns the TileLayer.
+    Given a TileMap and a layer path, this returns the TileLayer.
 
     :param pytiled_parser.objects.TileMap map_object: The map read in by the read_tmx function.
-    :param str layer_name: A string to match the layer name. Case sensitive.
+    :param str layer_path: A string to match the layer name. Case sensitive.
 
     :returns: A TileLayer, or None if no layer was found.
 
     """
 
     assert isinstance(map_object, pytiled_parser.objects.TileMap)
-    assert isinstance(layer_name, str)
+    assert isinstance(layer_path, str)
 
-    for layer in map_object.layers:
-        if layer.name == layer_name:
-            return layer
+    def _get_tilemap_layer(path, layers):
+        layer_name = path[0]
+        for layer in layers:
+            if layer.name == layer_name:
+                if layer.__class__ is pytiled_parser.objects.LayerGroup:
+                    path.pop(0)
+                    return _get_tilemap_layer(path, layer.layers)
+                else:
+                    return layer
+        return None
 
-    return None
-
+    path = layer_path.strip('/').split('/')
+    layer = _get_tilemap_layer(path, map_object.layers)
+    return layer
 
 def _get_tile_by_gid(map_object: pytiled_parser.objects.TileMap,
                      tile_gid: int) -> Optional[pytiled_parser.objects.Tile]:

--- a/tests/unit2/test_tilemap_objects.py
+++ b/tests/unit2/test_tilemap_objects.py
@@ -1,0 +1,69 @@
+import arcade
+
+#
+# Test size, rotation, alpha of tiles from a Tiled object layer
+# Also tests path traversal to get a layer within a layer group
+#
+
+def test_one():
+    tmx_map = arcade.tilemap.read_tmx(":resources:/tmx_maps/test_objects.tmx")
+
+    assert tmx_map.map_size.width == 20
+    assert tmx_map.map_size.height == 20
+    assert not tmx_map.infinite
+    assert tmx_map.orientation == "orthogonal"
+    assert tmx_map.render_order == 'right-down'
+    assert len(tmx_map.layers) == 4
+    assert tmx_map.background_color == (85, 170, 127)
+
+    tile_list = arcade.tilemap.process_layer(tmx_map, "Tiles", base_directory="test_data")
+    assert tile_list is not None
+    assert len(tile_list) == 2
+
+    sprite_1 = tile_list[0]
+    assert sprite_1 is not None
+    #
+    # Test width, height and angle
+    #
+    assert sprite_1.width == 400
+    assert sprite_1.height == 1000
+    assert sprite_1.angle == 45
+
+    # 
+    # Test type and name properties
+    #
+    assert sprite_1.properties['type'] == 'crate'
+    assert sprite_1.properties['name'] == 'crate1'
+    #
+    # Test getting layer in group
+    #
+    tile_list_2 = arcade.tilemap.process_layer(tmx_map, "Group/Tiles", base_directory="test_data")
+
+    assert tile_list_2 is not None
+    assert len(tile_list_2) == 2
+
+    sprite_2 = tile_list_2[0]
+    assert sprite_2 is not None
+    #
+    # Test width, height and angle
+    #
+    assert sprite_2.width == 600
+    assert sprite_2.height == 400
+    assert sprite_2.angle == -45
+    #
+    # Test alpha inherited from layer
+    #
+    assert sprite_2.alpha == int(255*.5)
+
+    #
+    # Future tests?
+    #
+    '''
+    shape_list = arcade.tilemap.process_layer(tmx_map, "Shapes", base_directory="test_data")
+    assert shape_list is not None
+    assert len(shape_list) == 4
+
+    text_list = arcade.tilemap.process_layer(tmx_map, "Text", base_directory="test_data")
+    assert text_list is not None
+    assert len(text_list) == 1
+    '''


### PR DESCRIPTION
This allows getting a layer by name as well as traversing layer groups to find a layer.  Ex: 'mylayer' or 'mygroup/mylayer'.  Leading and trailing slashes are stripped out to avoid errors.