### PR TITLE
Fixed hit_box being 1px less than intended #647

### DIFF
--- a/arcade/drawing_support.py
+++ b/arcade/drawing_support.py
@@ -205,6 +205,9 @@ def calculate_points(image):
     bottom_left_corner_offset = _check_corner_offset(left_border, bottom_border, 1, -1)
     bottom_right_corner_offset = _check_corner_offset(right_border, bottom_border, -1, -1)
 
+    right_border += 1
+    bottom_border += 1
+
     p1 = left_border + top_left_corner_offset, top_border
     p2 = right_border - top_right_corner_offset, top_border
     p3 = right_border, top_border + top_right_corner_offset

--- a/arcade/sound.py
+++ b/arcade/sound.py
@@ -118,11 +118,13 @@ def load_sound(file_name: str):
         return None
 
 
-def play_sound(sound: Sound):
+def play_sound(sound: Sound, volume: float=1.0, pan: float=0.0):
     """
     Play a sound.
 
     :param Sound sound: Sound loaded by load_sound. Do NOT use a string here for the filename.
+    :param float volume: Volume, from 0=quiet to 1=loud
+    :param float pan: Pan, from -1=left to 0=centered to 1=right
     """
     if sound is None:
         print("Unable to play sound, no data passed in.")
@@ -132,7 +134,7 @@ def play_sound(sound: Sound):
               "Make sure to use load_sound first, and use that result in play_sound."
         raise Exception(msg)
     try:
-        sound.play()
+        sound.play(volume, pan)
     except Exception as ex:
         print("Error playing sound.", ex)
 

--- a/arcade/text.py
+++ b/arcade/text.py
@@ -112,7 +112,8 @@ def draw_text(text: str,
               italic: bool = False,
               anchor_x: str = "left",
               anchor_y: str = "baseline",
-              rotation: float = 0
+              rotation: float = 0,
+              caching: bool = False
               ) -> Sprite:
     """
 
@@ -143,8 +144,9 @@ def draw_text(text: str,
     font_size *= scale_up
 
     # If the cache gets too large, dump it and start over.
-    if len(draw_text_cache) > 5000:
-        draw_text_cache = {}
+    if caching:
+        if len(draw_text_cache) > 1000:
+            draw_text_cache = {}
 
     r, g, b, alpha = get_four_byte_color(color)
     cache_color = f"{r}{g}{b}"
@@ -235,7 +237,8 @@ def draw_text(text: str,
         label.text_sprite_list = SpriteList()
         label.text_sprite_list.append(text_sprite)
 
-        draw_text_cache[key] = label
+        if caching:
+            draw_text_cache[key] = label
 
     text_sprite = label.text_sprite_list[0]
 


### PR DESCRIPTION
I added 1px to the `bottom_border` and `right_border` after all `image.getpixel()` calls to counteract the subtraction that was done before.

Let me know if this works. Thanks

#647