### PR TITLE
Added mouse_to_world_coordinates

### DIFF
--- a/arcade/experimental/camera.py
+++ b/arcade/experimental/camera.py
@@ -120,3 +120,8 @@ class Camera2D:
 
         self.update_zoom()
         self.set_viewport()
+        
+    def mouse_to_world_coordinates(self, x, y):
+        """ Returns the position of the mouse in world space. """
+        return (x / self.width * (self.right - self.left) + self.left,
+            y / self.height * (self.top - self.bottom) + self.bottom)


### PR DESCRIPTION
Converts the mouse coordinates (or screen space) to the world/camera coordinates. Could work on the name though, maybe it's a bit too long.